### PR TITLE
docs(setup): add explicit .venv setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Environment variable and authentication docs updated to use `COGSOL_API_KEY` and optional Azure AD B2C credentials.
 - Removed outdated "no external dependencies" statements from README.
+- Setup guides now explicitly document creating and activating a local `.venv` before installing dependencies.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,17 +58,19 @@ git remote add upstream https://github.com/Pyxis-Cognitive-Solutions/cogsol-fram
 
 ```bash
 # Create a virtual environment
-python -m venv venv
+python -m venv .venv
 
 # Activate it
 # Windows:
-venv\Scripts\activate
+.venv\Scripts\activate
 # macOS/Linux:
-source venv/bin/activate
+source .venv/bin/activate
 
 # Install with development dependencies
 pip install -e ".[dev]"
 ```
+
+Using a local `.venv` keeps dependencies isolated to this repository and avoids global package conflicts.
 
 ### Verify Installation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,11 +45,22 @@ python --version
 # Option A: Install from source
 git clone <repository-url> cogsol-framework
 cd cogsol-framework/framework
+
+# Create and activate a virtual environment
+python -m venv .venv
+# Windows:
+.venv\Scripts\activate
+# macOS/Linux:
+source .venv/bin/activate
+
+# Install dependencies
 pip install -e .
 
 # Option B: Install from PyPI (when available)
 pip install cogsol
 ```
+
+Using a local `.venv` keeps project dependencies isolated and prevents conflicts with global Python packages.
 
 ### Step 2: Verify Installation
 


### PR DESCRIPTION
## Description

Adds explicit local virtual environment setup steps to the contributor and getting-started documentation so installation is isolated from global Python packages and less error-prone for new contributors.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #16

## Changes Made

- Updated `CONTRIBUTING.md` to use `.venv` instead of `venv` and added platform-specific activation commands.
- Updated `docs/getting-started.md` to create and activate `.venv` before installing dependencies.
- Added a changelog entry in `CHANGELOG.md` documenting the setup guide update.
- Added short rationale text explaining that a local `.venv` helps avoid global dependency conflicts.

## Testing Done

- [x] Unit tests pass locally
- [ ] Added new tests for new functionality
- [x] Tested manually

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
