### PR TITLE
feat/mcp-servers: adding correct documentation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@ This document provides detailed reference documentation for all CogSol command-l
   - [ingest](#ingest)
   - [topics](#topics)
   - [importagent](#importagent)
+    - [addmcptools](#addmcptools)
   - [chat](#chat)
 - [Environment Configuration](#environment-configuration)
 - [Exit Codes](#exit-codes)
@@ -792,6 +793,103 @@ Imported assistant 42 as CustomerSupportAgent in agents/customer_support
 #### Generated Migration
 
 The command also creates a migration marking the import as applied, preventing duplicate creation on next `migrate`. When retrievals or topics are imported, a data migration is created and marked applied as well.
+
+---
+
+### addmcptools
+
+Interactively register an MCP server, select the desired available MCP tools and link them to your agent.
+
+#### Synopsis
+
+```bash
+python manage.py addmcptools
+```
+
+#### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--app` | `agents` | App folder where `mcp_servers.py` and `mcp_tools.py` are created/updated |
+| `--oauth-timeout` | `300` | Max seconds to wait for OAuth completion in browser flow | (Optional)
+
+
+#### What This Command Does
+
+1. **Collects server configuration**
+2. **Discovers tools from the MCP endpoint** (with OAuth-assisted discovery when needed)
+3. **Generates/updates local Python definitions**
+4. **Publishes mcp server + selected tools to your agent immediately**
+
+#### Authentication Modes
+
+| Auth Type | Use Case | Notes |
+|----------|----------|-------|
+| `none` | Public MCP server | No credentials required |
+| `headers` | API key or static headers | Header values are saved as env vars in `.env` |
+| `oauth2` | OAuth 2.1 / MCP server | `client_id` and scopes are optional; `client_secret` is never written to source or `.env` |
+
+#### Generated or Updated Files
+
+| File | Purpose |
+|------|---------|
+| `<app>/mcp_servers.py` | MCP server classes (`BaseMCPServer`) |
+| `<app>/mcp_tools.py` | MCP tool classes (`BaseMCPTool`) linked to selected server |
+| `.env` | New non-secret MCP variables (headers, optional OAuth client metadata) |
+
+#### Step-by-Step: Add a New MCP Server
+
+1. Run the command:
+
+```bash
+python manage.py addmcptools
+```
+
+2. Enter server metadata when prompted:
+    - Server name
+    - Description (optional)
+    - MCP URL
+    - Auth mode (`none`, `headers`, or `oauth2`)
+
+3. Provide credentials based on auth mode:
+    - `headers`: add one or more headers and values
+    - `oauth2`: optionally provide client ID/scopes, optionally client secret (write-only to API)
+
+4. Select tools to import (`all` or comma-separated indices).
+
+5. Review created/updated files:
+    - `<app>/mcp_servers.py`
+    - `<app>/mcp_tools.py`
+    - `.env`
+
+6. Generate and apply migrations:
+
+```bash
+python manage.py makemigrations
+python manage.py migrate
+```
+
+7. If OAuth re-authorization is requested, complete the browser flow and re-run
+    `addmcptools` if needed.
+
+#### Example Usage and Outputs
+
+```bash
+# Default app (agents)
+python manage.py addmcptools
+.
+.
+.
+follow the options provided from the cli and cotinue the flow
+
+#### Output Highlights
+
+| Message | Meaning |
+|---------|---------|
+| "Found N tool(s)" | Tool discovery succeeded |
+| "Created/Updated MCP server" | Server was published to remote catalog |
+| "Synced N MCP tool(s)" | Tool selection was published |
+| "Run 'python manage.py makemigrations' followed by 'python manage.py migrate'" | Next step to persist local definitions in your project lifecycle |
 
 ---
 


### PR DESCRIPTION
## Description

Adds documentation for the addmcptools command, including a practical onboarding flow to register MCP servers and sync tools.  
Also improves command discoverability by adding addmcptools to the commands index.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Proper documentation of the new command related to mcp servers

## Changes Made

- Added a new addmcptools section to the CLI reference with purpose and command scope.
- Documented the full step-by-step workflow to add MCP servers, configure authentication, select tools, and continue with migrations.
- Included options, authentication modes, generated files, and expected output messages to guide troubleshooting and usage.

## Testing Done

- [ ] Unit tests pass locally
- [ ] Added new tests for new functionality
- [x] Tested manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
