### PR TITLE
fix(migrations): resolve retrieval metadata filters

### DIFF
--- a/cogsol/core/loader.py
+++ b/cogsol/core/loader.py
@@ -82,6 +82,8 @@ def serialize_value(value: Any) -> Any:
             return getattr(value, "name", None) or value.__name__
         if issubclass(value, BaseIngestionConfig):
             return getattr(value, "name", None) or value.__name__
+        if issubclass(value, BaseMetadataConfig):
+            return getattr(value, "name", None) or value.__name__
         if issubclass(value, BaseRetrievalTool):
             return getattr(value, "name", None) or value.__name__
     if is_dataclass(value) and not isinstance(value, type):
@@ -582,7 +584,8 @@ def collect_classes(project_path: Path, app_name: str = "agents") -> dict[str, d
                     or obj.__module__.startswith(retrieval_prefix)
                 )
             ):
-                classes["retrieval_tools"][obj.__name__] = obj
+                key = getattr(obj, "name", None) or obj.__name__
+                classes["retrieval_tools"][key] = obj
     except ModuleNotFoundError as exc:
         if not _ignore_missing_module(exc, f"{app_name}.searches"):
             _raise_import_error("retrieval tools module", f"{app_name}.searches", exc)

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -407,6 +407,46 @@ class Command(BaseCommand):
                     created.append(("formatter", None, new_id))
                 new_remote.setdefault("formatters", {})[fmt_name] = new_id
 
+            # Upsert metadata configs before retrievals, since filters reference them.
+            for cfg_key, definition in state.get("metadata_configs", {}).items():
+                if touched is not None and cfg_key not in touched.get("metadata_configs", set()):
+                    continue
+                fields = definition.get("fields", {})
+                topic_path = definition.get("topic", "")
+                cfg_name = fields.get("name")
+                if not topic_path or not cfg_name:
+                    continue
+                node_id = topic_id_map.get(topic_path) or new_remote.get("topics", {}).get(
+                    topic_path
+                )
+                if not node_id:
+                    continue
+
+                cfg_payload = {
+                    "name": cfg_name,
+                    "type": fields.get("type", "STRING"),
+                    "possible_values": fields.get("possible_values", []),
+                    "default_value": fields.get("default_value"),
+                    "format": fields.get("format"),
+                    "filtrable": fields.get("filtrable", False),
+                    "required": fields.get("required", False),
+                    "in_embedding": fields.get("in_embedding", False),
+                    "in_retrieval": fields.get("in_retrieval", True),
+                }
+                if cfg_payload["required"] and cfg_payload.get("default_value") is None:
+                    raise CogSolAPIError(
+                        "Default value is required for required metadata configs. "
+                        f"Set default_value for '{cfg_key}'."
+                    )
+
+                cfg_remote_id = new_remote.get("metadata_configs", {}).get(cfg_key)
+                if cfg_remote_id:
+                    client.update_metadata_config(cfg_remote_id, cfg_payload)
+                else:
+                    new_cfg_id = client.create_metadata_config(node_id=node_id, payload=cfg_payload)
+                    created.append(("metadata_config", node_id, new_cfg_id))
+                    new_remote.setdefault("metadata_configs", {})[cfg_key] = new_cfg_id
+
             # Upsert retrievals
             for ret_name, definition in state.get("retrievals", {}).items():
                 if touched is not None and ret_name not in touched.get("retrievals", set()):
@@ -451,7 +491,36 @@ class Command(BaseCommand):
                 _set_if_defined("next_blocks")
                 _set_if_defined("contingency_for_embedding")
                 _set_if_defined("threshold_similarity")
-                _set_if_defined("filters")
+                if "filters" in fields:
+                    filters_value = fields.get("filters")
+                    if filters_value is not None:
+                        if not isinstance(filters_value, list):
+                            raise CogSolAPIError(
+                                "filters must be a list of metadata config names or ids. "
+                                f"Fix retrieval '{ret_name}'."
+                            )
+                        metadata_configs = new_remote.get("metadata_configs", {})
+                        filters_payload: list[int] = []
+                        for filter_ref in filters_value:
+                            if isinstance(filter_ref, int):
+                                filters_payload.append(filter_ref)
+                                continue
+                            if not isinstance(filter_ref, str):
+                                raise CogSolAPIError(
+                                    "filters entries must be metadata config names or ids. "
+                                    f"Fix retrieval '{ret_name}'."
+                                )
+                            filter_id = metadata_configs.get(filter_ref)
+                            if filter_id is None and topic_name and "/" not in filter_ref:
+                                filter_id = metadata_configs.get(f"{topic_name}/{filter_ref}")
+                            if filter_id is None:
+                                raise CogSolAPIError(
+                                    "MetadataConfig must be migrated before use as filter. "
+                                    f"Missing metadata config id for '{filter_ref}' "
+                                    f"in retrieval '{ret_name}'."
+                                )
+                            filters_payload.append(int(filter_id))
+                        retrieval_payload["filters"] = filters_payload
 
                 if (
                     "strategy_reordering" in retrieval_payload
@@ -524,46 +593,6 @@ class Command(BaseCommand):
                 if not remote_id:
                     created.append(("ingestion_config", None, new_id))
                 new_remote.setdefault("ingestion_configs", {})[cfg_name] = new_id
-
-            # Upsert metadata configs
-            for cfg_key, definition in state.get("metadata_configs", {}).items():
-                if touched is not None and cfg_key not in touched.get("metadata_configs", set()):
-                    continue
-                fields = definition.get("fields", {})
-                topic_path = definition.get("topic", "")
-                cfg_name = fields.get("name")
-                if not topic_path or not cfg_name:
-                    continue
-                node_id = topic_id_map.get(topic_path) or new_remote.get("topics", {}).get(
-                    topic_path
-                )
-                if not node_id:
-                    continue
-
-                cfg_payload = {
-                    "name": cfg_name,
-                    "type": fields.get("type", "STRING"),
-                    "possible_values": fields.get("possible_values", []),
-                    "default_value": fields.get("default_value"),
-                    "format": fields.get("format"),
-                    "filtrable": fields.get("filtrable", False),
-                    "required": fields.get("required", False),
-                    "in_embedding": fields.get("in_embedding", False),
-                    "in_retrieval": fields.get("in_retrieval", True),
-                }
-                if cfg_payload["required"] and cfg_payload.get("default_value") is None:
-                    raise CogSolAPIError(
-                        "Default value is required for required metadata configs. "
-                        f"Set default_value for '{cfg_key}'."
-                    )
-
-                cfg_remote_id = new_remote.get("metadata_configs", {}).get(cfg_key)
-                if cfg_remote_id:
-                    client.update_metadata_config(cfg_remote_id, cfg_payload)
-                else:
-                    new_cfg_id = client.create_metadata_config(node_id=node_id, payload=cfg_payload)
-                    created.append(("metadata_config", node_id, new_cfg_id))
-                    new_remote.setdefault("metadata_configs", {})[cfg_key] = new_cfg_id
 
             return new_remote, created
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 
 from cogsol.agents import BaseAgent, genconfigs, optimizations
-from cogsol.core.loader import collect_definitions
+from cogsol.core.loader import collect_classes, collect_definitions
 from cogsol.core.migrations import diff_states, empty_state
 from cogsol.db.migrations import (
     AlterField,
@@ -276,6 +276,10 @@ class ProductDocsSearch(BaseRetrievalTool):
 
             defs = collect_definitions(project_path, "agents")
             assert "product_docs_search" in defs["retrieval_tools"]
+
+            classes = collect_classes(project_path, "agents")
+            assert "product_docs_search" in classes["retrieval_tools"]
+            assert "ProductDocsSearch" not in classes["retrieval_tools"]
 
             ops = diff_states(empty_state(), defs, app="agents")
             create_ops = [op for op in ops if isinstance(op, CreateRetrievalTool)]

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -5,8 +5,10 @@ Tests for Content API loader and migrations.
 import tempfile
 from pathlib import Path
 
+from cogsol.content import BaseMetadataConfig
 from cogsol.core.loader import (
     collect_content_definitions,
+    serialize_value,
 )
 from cogsol.core.migrations import (
     diff_states,
@@ -146,6 +148,15 @@ class TestDiffStatesContent:
 
 class TestCollectContentDefinitions:
     """Tests for collect_content_definitions function."""
+
+    def test_serializes_metadata_config_filter_reference(self):
+        """Metadata filter classes should serialize to migration-safe names."""
+
+        class CategoryMetadata(BaseMetadataConfig):
+            name = "category"
+
+        assert serialize_value(CategoryMetadata) == "category"
+        assert serialize_value([CategoryMetadata]) == ["category"]
 
     def test_returns_empty_when_no_data_folder(self):
         """Should return empty state when data/ doesn't exist."""

--- a/tests/test_migrate_tools.py
+++ b/tests/test_migrate_tools.py
@@ -408,6 +408,72 @@ class TestMigrateMCPAssociationOnly:
         assert remote["mcp_tools"]["ping"] == 901
 
 
+class TestContentMigrationFilters:
+    def test_resolves_retrieval_filters_to_metadata_config_ids(self, monkeypatch) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        class FakeClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def upsert_node(self, *, remote_id, payload):
+                calls.append(("topic", payload))
+                return remote_id or 10
+
+            def create_metadata_config(self, *, node_id, payload):
+                calls.append(("metadata_config", payload))
+                return 20
+
+            def update_metadata_config(self, _config_id, payload):
+                calls.append(("metadata_config", payload))
+
+            def upsert_retrieval(self, *, remote_id, payload):
+                calls.append(("retrieval", payload))
+                return remote_id or 30
+
+        monkeypatch.setattr("cogsol.management.commands.migrate.CogSolClient", FakeClient)
+
+        cmd = Command()
+        state = {
+            "topics": {
+                "docs": {
+                    "fields": {"name": "docs"},
+                    "meta": {},
+                }
+            },
+            "formatters": {},
+            "metadata_configs": {
+                "docs/category": {
+                    "fields": {"name": "category", "filtrable": True},
+                    "topic": "docs",
+                }
+            },
+            "retrievals": {
+                "doc_search": {
+                    "fields": {
+                        "name": "doc_search",
+                        "topic": "docs",
+                        "filters": ["category"],
+                    }
+                }
+            },
+            "ingestion_configs": {},
+        }
+
+        cmd._sync_content_with_api(
+            api_base="https://api.invalid",
+            api_key=None,
+            state=state,
+            remote_ids=cmd._empty_content_remote(),
+            class_map={},
+            project_path=Path("."),
+            touched=None,
+        )
+
+        assert [kind for kind, _ in calls] == ["topic", "metadata_config", "retrieval"]
+        assert calls[-1][1]["filters"] == [20]
+
+
 class TestRollbackDeleteDispatch:
     def test_delete_created_entry_supports_mcp_tool(self) -> None:
         class FakeClient:


### PR DESCRIPTION
Fixes #38
Fixes #39

This supersedes #10 with a smaller patch rebased on current main.

## Summary
- Serialize `BaseMetadataConfig` filter references by name.
- Key retrieval tool classes by explicit `name`, matching collected definitions.
- Sync metadata configs before retrievals.
- Resolve retrieval filters to metadata config remote IDs before sending the retrieval payload.