### PR TITLE
Fixes regarding issues about metadata-config, script tools code and a…

### DIFF
--- a/cogsol/agents/__init__.py
+++ b/cogsol/agents/__init__.py
@@ -40,6 +40,8 @@ class BaseAgent:
     streaming: bool = False
     self_improvement_mode: bool = False
     realtime: bool = False
+    reasoning: bool = False
+    websearch: bool = False
     lessons: list[Any] = []
     faqs: list[Any] = []
     fixed_responses: list[Any] = []

--- a/cogsol/management/commands/credentialssetup.py
+++ b/cogsol/management/commands/credentialssetup.py
@@ -31,16 +31,16 @@ class Command(BaseCommand):
         if "401" in error_msg:
             return "Invalid API key — double-check your tenant_api_key."
         if "403" in error_msg:
-            return "Your client_id and tenant_api_key may not match — double-check your credentials."
+            return (
+                "Your client_id and tenant_api_key may not match — double-check your credentials."
+            )
         if "500" in error_msg:
             return "Server error — the API may be experiencing issues, try again later."
         if "Connection error" in error_msg:
             return "Could not reach the server — check your internet connection."
         return ""
 
-    def _check_connectivity(
-        self, client_id: str, client_secret: str, tenant_api_key: str
-    ) -> None:
+    def _check_connectivity(self, client_id: str, client_secret: str, tenant_api_key: str) -> None:
         os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["client_id"]] = client_id
         os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["client_secret"]] = client_secret
         os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["tenant_api_key"]] = tenant_api_key

--- a/cogsol/management/commands/credentialssetup.py
+++ b/cogsol/management/commands/credentialssetup.py
@@ -47,18 +47,24 @@ class Command(BaseCommand):
 
         print("\nChecking API connectivity...")
 
-        client = CogSolClient(api_key=tenant_api_key)
         error_msg = None
+        client = None
 
-        for check in [
-            lambda: client.list_mcp_servers(),
-            lambda: client.list_nodes(),
-        ]:
-            try:
-                check()
-            except (CogSolAPIError, Exception) as exc:
-                error_msg = str(exc)
-                break
+        try:
+            client = CogSolClient(api_key=tenant_api_key)
+        except (CogSolAPIError, Exception) as exc:
+            error_msg = str(exc)
+
+        if client is not None:
+            for check in [
+                lambda: client.list_mcp_servers(),
+                lambda: client.list_nodes(),
+            ]:
+                try:
+                    check()
+                except (CogSolAPIError, Exception) as exc:
+                    error_msg = str(exc)
+                    break
 
         if error_msg is None:
             print("  CogSol API: OK")

--- a/cogsol/management/commands/credentialssetup.py
+++ b/cogsol/management/commands/credentialssetup.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import os
 from getpass import getpass
 from pathlib import Path
 from typing import Any
 
-from cogsol.core.credentials import ONBOARDING_MESSAGE, save_credentials
+from cogsol.core.api import CogSolAPIError, CogSolClient
+from cogsol.core.credentials import (
+    CREDENTIAL_FIELD_TO_ENV_VAR,
+    ONBOARDING_MESSAGE,
+    save_credentials,
+)
 from cogsol.management.base import BaseCommand
 
 
@@ -20,6 +26,47 @@ class Command(BaseCommand):
             return getpass(prompt).strip()
         except Exception:
             return input(prompt).strip()
+
+    def _error_hint(self, error_msg: str) -> str:
+        if "401" in error_msg:
+            return "Invalid API key — double-check your tenant_api_key."
+        if "403" in error_msg:
+            return "Your client_id and tenant_api_key may not match — double-check your credentials."
+        if "500" in error_msg:
+            return "Server error — the API may be experiencing issues, try again later."
+        if "Connection error" in error_msg:
+            return "Could not reach the server — check your internet connection."
+        return ""
+
+    def _check_connectivity(
+        self, client_id: str, client_secret: str, tenant_api_key: str
+    ) -> None:
+        os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["client_id"]] = client_id
+        os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["client_secret"]] = client_secret
+        os.environ[CREDENTIAL_FIELD_TO_ENV_VAR["tenant_api_key"]] = tenant_api_key
+
+        print("\nChecking API connectivity...")
+
+        client = CogSolClient(api_key=tenant_api_key)
+        error_msg = None
+
+        for check in [
+            lambda: client.list_mcp_servers(),
+            lambda: client.list_nodes(),
+        ]:
+            try:
+                check()
+            except (CogSolAPIError, Exception) as exc:
+                error_msg = str(exc)
+                break
+
+        if error_msg is None:
+            print("  CogSol API: OK")
+        else:
+            print(f"  CogSol API: FAILED — {error_msg}")
+            hint = self._error_hint(error_msg)
+            if hint:
+                print(f"  Hint: {hint}")
 
     def handle(self, project_path: Path | None, **options: Any) -> int:
         print(ONBOARDING_MESSAGE)
@@ -44,4 +91,7 @@ class Command(BaseCommand):
             return 1
 
         print(f"Credentials saved to {target}.")
+
+        self._check_connectivity(client_id, client_secret, tenant_api_key)
+
         return 0

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -247,6 +247,11 @@ def _formatter_class_name(name: str) -> str:
     return base if base.endswith("Formatter") else base + "Formatter"
 
 
+def _metadata_config_class_name(name: str) -> str:
+    base = _safe_class_name(name, "Metadata")
+    return base if base.endswith("Metadata") else base + "Metadata"
+
+
 def _faq_class(item: dict[str, Any]) -> str:
     name = item.get("name") or item.get("question") or "FAQ"
     cls_name = _safe_class_name(name, "FAQ") + "FAQ"
@@ -344,6 +349,34 @@ class Command(BaseCommand):
         gen_pre_expr = "genconfigs.QA()" if str(gen_pre).upper() == "QA" else repr(gen_pre)
 
         has_retrieval_tools = False
+        _colors = assistant.get("colors") or {}
+        _name_color = _colors.get("nameColor")
+        _primary_color = _colors.get("primaryColor")
+        _secondary_color = _colors.get("secondaryColor")
+        _border_color = _colors.get("borderColor")
+        _reasoning = bool(assistant.get("reasoning_available", False))
+        _websearch = bool(assistant.get("websearch_available", False))
+
+        _meta_lines = [
+            f"        name = {class_name!r}",
+            f"        chat_name = {agent_desc!r}",
+            f"        logo_url = {assistant.get('logo')!r}",
+        ]
+        if _name_color:
+            _meta_lines.append(f"        assistant_name_color = {_name_color!r}")
+        if _primary_color:
+            _meta_lines.append(f"        primary_color = {_primary_color!r}")
+        if _secondary_color:
+            _meta_lines.append(f"        secondary_color = {_secondary_color!r}")
+        if _border_color:
+            _meta_lines.append(f"        border_color = {_border_color!r}")
+
+        _extra_fields = ""
+        if _reasoning:
+            _extra_fields += f"    reasoning = True\n"
+        if _websearch:
+            _extra_fields += f"    websearch = True\n"
+
         agent_py = f"""from cogsol.agents import BaseAgent, genconfigs
 from cogsol.prompts import Prompts
 from ..tools import *
@@ -362,11 +395,9 @@ class {class_name}(BaseAgent):
     initial_message = {assistant.get("initial_message")!r}
     forced_termination_message = {assistant.get("end_message")!r}
     no_information_message = {assistant.get("not_info_message")!r}
-
+{_extra_fields}
     class Meta:
-        name = {class_name!r}
-        chat_name = {agent_desc!r}
-        logo_url = {assistant.get("logo")!r}
+{chr(10).join(_meta_lines)}
 """
         _write_file(agent_dir / "agent.py", agent_py)
         _write_file(agent_dir / "__init__.py", f"from .agent import {class_name}\n")
@@ -564,6 +595,8 @@ class {class_name}(BaseAgent):
             "no_information_message": assistant.get("not_info_message"),
             "streaming": assistant.get("streaming_available"),
             "realtime": assistant.get("realtime_available"),
+            "reasoning": assistant.get("reasoning_available"),
+            "websearch": assistant.get("websearch_available"),
             "tools": [n for n in (_tool_name_for_id(sid) for sid in tools_ids) if n],
             "pretools": [n for n in (_tool_name_for_id(sid) for sid in pretools_ids) if n],
             "faqs": [
@@ -594,11 +627,19 @@ class {class_name}(BaseAgent):
                 for le in lessons
             ],
         }
-        meta = {
+        meta: dict[str, Any] = {
             "name": class_name,
             "chat_name": agent_desc,
             "logo_url": assistant.get("logo"),
         }
+        if _name_color:
+            meta["assistant_name_color"] = _name_color
+        if _primary_color:
+            meta["primary_color"] = _primary_color
+        if _secondary_color:
+            meta["secondary_color"] = _secondary_color
+        if _border_color:
+            meta["border_color"] = _border_color
 
         ops_lines = (
             tool_ops
@@ -738,9 +779,11 @@ class {class_name}(BaseAgent):
 
             imported_topics: dict[str, dict[str, Any]] = {}
             imported_formatters: dict[str, dict[str, Any]] = {}
+            imported_metadata_configs: dict[str, dict[str, Any]] = {}
             imported_retrievals: dict[str, dict[str, Any]] = {}
             remote_topics: dict[str, int] = {}
             remote_formatters: dict[str, int] = {}
+            remote_metadata_configs: dict[str, int] = {}
             remote_retrievals: dict[str, int] = {}
             formatter_class_names: dict[int, str] = {}
 
@@ -912,8 +955,67 @@ class {class_name}(BaseAgent):
                     )
                 if formatters_literal:
                     retrieval_lines.append(f"    formatters = {formatters_literal}")
-                if "filters" in retrieval:
-                    retrieval_lines.append(f"    filters = {retrieval.get('filters')!r}")
+
+                # Fetch metadata configs for the topic node and generate classes.
+                # The GET /retrievals/{id}/ endpoint does not expose which metadata
+                # configs are assigned as filters, so we import all metadata configs
+                # for the topic. The user can then assign filters in BaseRetrieval.
+                if isinstance(node_id, int) and topic_path:
+                    try:
+                        topic_cfgs = client.list_metadata_configs(node_id=node_id) or []
+                    except CogSolAPIError:
+                        topic_cfgs = []
+
+                    module_dir = data_path.joinpath(*topic_path.split("/"))
+                    metadata_file = module_dir / "metadata.py"
+
+                    for cfg in topic_cfgs:
+                        if not isinstance(cfg, dict):
+                            continue
+                        cfg_id = cfg.get("id")
+                        cfg_name = cfg.get("name") or f"metadata_{cfg_id}"
+                        cfg_class = _metadata_config_class_name(str(cfg_name))
+                        cfg_key = f"{topic_path}/{cfg_name}"
+
+                        _ensure_import(
+                            metadata_file,
+                            "from cogsol.content import BaseMetadataConfig, MetadataType",
+                        )
+                        cfg_lines = [
+                            f"class {cfg_class}(BaseMetadataConfig):",
+                            '    """Metadata config imported from CogSol API."""',
+                            f"    name = {cfg_name!r}",
+                            f"    type = MetadataType.{cfg.get('type') or 'STRING'}",
+                        ]
+                        if cfg.get("possible_values"):
+                            cfg_lines.append(f"    possible_values = {cfg['possible_values']!r}")
+                        cfg_lines.append(f"    filtrable = {bool(cfg.get('filtrable', False))}")
+                        if _append_block(
+                            metadata_file,
+                            "\n".join(cfg_lines),
+                            f"class {cfg_class}(BaseMetadataConfig):",
+                        ):
+                            import_messages.append(
+                                f"Metadata config: {cfg_name} -> {metadata_file}"
+                            )
+
+                        if cfg_key not in imported_metadata_configs:
+                            imported_metadata_configs[cfg_key] = {
+                                "fields": {
+                                    "name": cfg_name,
+                                    "type": cfg.get("type", "STRING"),
+                                    "possible_values": cfg.get("possible_values") or [],
+                                    "default_value": cfg.get("default_value"),
+                                    "format": cfg.get("format"),
+                                    "filtrable": bool(cfg.get("filtrable", False)),
+                                    "required": bool(cfg.get("required", False)),
+                                    "in_embedding": bool(cfg.get("in_embedding", False)),
+                                    "in_retrieval": bool(cfg.get("in_retrieval", True)),
+                                },
+                                "topic": topic_path,
+                            }
+                            if isinstance(cfg_id, int):
+                                remote_metadata_configs[cfg_key] = cfg_id
 
                 retrieval_block = "\n".join(retrieval_lines)
                 if _append_block(
@@ -939,14 +1041,13 @@ class {class_name}(BaseAgent):
                         "threshold_similarity": retrieval.get("threshold_similarity"),
                         "max_msg_length": retrieval.get("max_msg_length"),
                         "formatters": formatters_value or {},
-                        "filters": retrieval.get("filters"),
                     },
                     "meta": {},
                 }
                 if isinstance(retrieval.get("id"), int):
                     remote_retrievals[retrieval_name] = int(retrieval["id"])
 
-            if imported_topics or imported_formatters or imported_retrievals:
+            if imported_topics or imported_formatters or imported_metadata_configs or imported_retrievals:
                 data_migrations = data_path / "migrations"
                 data_migrations.mkdir(parents=True, exist_ok=True)
                 data_mig_name = next_migration_name(data_migrations, explicit_name=f"import_{slug}")
@@ -962,6 +1063,12 @@ class {class_name}(BaseAgent):
                     ops_lines.append(
                         f"        migrations.CreateReferenceFormatter(name={fmt_name!r}, "
                         f"fields={definition['fields']!r}),"
+                    )
+                # Metadata configs must come before retrievals (filters reference them)
+                for cfg_key, definition in imported_metadata_configs.items():
+                    ops_lines.append(
+                        f"        migrations.CreateMetadataConfig(name={cfg_key!r}, "
+                        f"fields={definition['fields']!r}, topic={definition['topic']!r}),"
                     )
                 for ret_name, definition in imported_retrievals.items():
                     ops_lines.append(
@@ -1010,6 +1117,9 @@ class {class_name}(BaseAgent):
                 data_state.setdefault("remote", {}).setdefault("topics", {}).update(remote_topics)
                 data_state.setdefault("remote", {}).setdefault("formatters", {}).update(
                     remote_formatters
+                )
+                data_state.setdefault("remote", {}).setdefault("metadata_configs", {}).update(
+                    remote_metadata_configs
                 )
                 data_state.setdefault("remote", {}).setdefault("retrievals", {}).update(
                     remote_retrievals

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -373,9 +373,9 @@ class Command(BaseCommand):
 
         _extra_fields = ""
         if _reasoning:
-            _extra_fields += f"    reasoning = True\n"
+            _extra_fields += "    reasoning = True\n"
         if _websearch:
-            _extra_fields += f"    websearch = True\n"
+            _extra_fields += "    websearch = True\n"
 
         agent_py = f"""from cogsol.agents import BaseAgent, genconfigs
 from cogsol.prompts import Prompts
@@ -1047,7 +1047,12 @@ class {class_name}(BaseAgent):
                 if isinstance(retrieval.get("id"), int):
                     remote_retrievals[retrieval_name] = int(retrieval["id"])
 
-            if imported_topics or imported_formatters or imported_metadata_configs or imported_retrievals:
+            if (
+                imported_topics
+                or imported_formatters
+                or imported_metadata_configs
+                or imported_retrievals
+            ):
                 data_migrations = data_path / "migrations"
                 data_migrations.mkdir(parents=True, exist_ok=True)
                 data_mig_name = next_migration_name(data_migrations, explicit_name=f"import_{slug}")

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -1135,13 +1135,13 @@ class Command(BaseCommand):
 
         colors = {}
         if _get_meta("assistant_name_color"):
-            colors["assistant_name_color"] = _get_meta("assistant_name_color")
+            colors["nameColor"] = _get_meta("assistant_name_color")
         if _get_meta("primary_color"):
-            colors["primary_color"] = _get_meta("primary_color")
+            colors["primaryColor"] = _get_meta("primary_color")
         if _get_meta("secondary_color"):
-            colors["secondary_color"] = _get_meta("secondary_color")
+            colors["secondaryColor"] = _get_meta("secondary_color")
         if _get_meta("border_color"):
-            colors["border_color"] = _get_meta("border_color")
+            colors["borderColor"] = _get_meta("border_color")
 
         payload = {
             "generation_config": _normalize_config(_get("generation_config")),
@@ -1177,7 +1177,9 @@ class Command(BaseCommand):
                 getattr(cls, "lessons", []) if cls else fields.get("lessons")
             ),
             "realtime_available": bool(_get("realtime", False)),
-            "info": None,
+            "reasoning_available": bool(_get("reasoning", False)),
+            "websearch_available": bool(_get("websearch", False)),
+            "info": _get_meta("chat_name"),
             "colors": colors,
             "logo": _get_meta("logo_url"),
             "streaming_available": bool(_get("streaming", False)),
@@ -1360,9 +1362,6 @@ class Command(BaseCommand):
 
         source = _normalize_code(source)
         lines = source.splitlines()
-        # Strip decorator lines if any (not expected but safe).
-        while lines and lines[0].lstrip().startswith("@"):
-            lines.pop(0)
 
         try:
             fn_tree = ast.parse(source)

--- a/tests/test_api_key_errors.py
+++ b/tests/test_api_key_errors.py
@@ -5,10 +5,12 @@ Tests for credential-related error handling and fail-fast checks.
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from cogsol.core import credentials as credentials_mod
 from cogsol.core.api import CogSolAPIError, CogSolClient
 from cogsol.core.credentials import CREDENTIALS_NOT_CONFIGURED_MESSAGE
 
@@ -29,13 +31,19 @@ def _bare_client() -> CogSolClient:
 
 
 def _clear_credentials_env(monkeypatch) -> None:
-    for env_var in ("COGSOL_API_KEY", "COGSOL_AUTH_CLIENT_ID", "COGSOL_AUTH_SECRET"):
+    for env_var in (
+        "COGSOL_API_KEY",
+        "COGSOL_AUTH_CLIENT_ID",
+        "COGSOL_AUTH_SECRET",
+        "COGSOL_ENV",
+        "cogsol_env",
+    ):
         monkeypatch.delenv(env_var, raising=False)
 
 
 def _isolate_credentials_store(monkeypatch, tmp_path) -> None:
-    # Force credentials.json lookups into the test temp directory.
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    creds_path = Path(tmp_path) / ".config" / "cogsol" / "credentials.json"
+    monkeypatch.setattr(credentials_mod, "get_credentials_path", lambda: creds_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -172,6 +172,32 @@ def test_credentials_setup_command_saves_credentials(tmp_path, monkeypatch):
     }
 
 
+def test_credentials_setup_command_handles_connectivity_failure_on_client_init(
+    tmp_path, monkeypatch
+):
+    _clear_credential_env(monkeypatch)
+    _isolate_store(monkeypatch, tmp_path)
+
+    answers = iter(["client-id"])
+    secrets = iter(["client-secret", "tenant-key"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    monkeypatch.setattr(CredentialsSetupCommand, "_ask_secret", lambda self, _prompt: next(secrets))
+    monkeypatch.setattr(
+        "cogsol.management.commands.credentialssetup.CogSolClient",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("invalid_grant")),
+    )
+
+    result = CredentialsSetupCommand().handle(project_path=None)
+
+    assert result == 0
+    assert load_stored_credentials(credentials_mod.get_credentials_path()) == {
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "tenant_api_key": "tenant-key",
+    }
+
+
 def test_clear_credentials_command_removes_file_and_env(tmp_path, monkeypatch):
     _clear_credential_env(monkeypatch)
     _isolate_store(monkeypatch, tmp_path)

--- a/tests/test_migrate_tools.py
+++ b/tests/test_migrate_tools.py
@@ -251,6 +251,22 @@ class TestToolScriptFromClass:
         assert 'response = {"lat": latitude, "lon": longitude}' in script
         ast.parse(script)
 
+    def test_includes_import_in_decorated_run(self) -> None:
+        from cogsol.tools import tool_params
+
+        class EncodeTool(BaseTool):
+            @tool_params(text={"description": "Text to encode", "type": "string", "required": True})
+            def run(self, text: str = "", chat=None, data=None, secrets=None, log=None):
+                import base64
+
+                return base64.b64encode(text.encode()).decode()
+
+        script = Command()._tool_script_from_class(EncodeTool)
+
+        assert "import base64" in script
+        assert "text = params.get('text')" in script
+        ast.parse(script)
+
 
 class TestMigrateMCPAssociationOnly:
     def test_hydrates_mcp_ids_and_associates_existing_tool(self, monkeypatch) -> None:


### PR DESCRIPTION
## Agent customization

## Description

This PR addresses several bugs affecting agent customization, tool code generation, credentials setup, and data import from the CogSol platform.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**Tool code generation (`migrate.py`)**
- Fixed `import` statements (e.g. `import base64`) being silently dropped from tool `run()` methods that use a `@tool_params` decorator. The decorator stripping loop was shifting line indices out of sync with the AST, causing the first statement of the body to be skipped.

**Agent personalization (`migrate.py`, `agents/__init__.py`)**
- Fixed color field names sent to the API: framework used `primary_color`, `secondary_color`, `border_color`, `assistant_name_color` but the API expects `primaryColor`, `secondaryColor`, `borderColor`, `nameColor`.
- Fixed `info` field always being sent as `None`; it now uses `Meta.chat_name`.
- Added `reasoning` and `websearch` boolean fields to `BaseAgent` and wired them to `reasoning_available` / `websearch_available` in the API payload.

**Credentials setup (`credentialssetup.py`)**
- After saving credentials, the command now performs a connectivity check against both the Cognitive and Content APIs and reports a single `CogSol API: OK / FAILED` result with a hint for common error codes (401, 403, 500).

**Agent import (`importagent.py`)**
- Fixed metadata configs not being imported when importing an agent with retrieval tools. The command now calls `list_metadata_configs(node_id=...)` for each retrieval's topic and generates `BaseMetadataConfig` classes in `data/<topic>/metadata.py`, `CreateMetadataConfig` migration operations, and saves remote IDs in `.state.json`.
- Fixed agent personalization (colors, `chat_name`, `logo_url`, `reasoning`, `websearch`) not being written to the generated `agent.py` or the import migration's `meta` dict.

## Testing Done

- [x] Unit tests pass locally
- [x] Added new test `TestToolScriptFromClass::test_includes_import_in_decorated_run` covering the `@tool_params` + `import` fix
- [x] Tested `importagent` manually against a live tenant with retrieval tools and filters
- [x] Tested `credentials-setup` connectivity check with valid and invalid credentials

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
