### PR TITLE
Fix mcp server deletions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `cogsol-admin startproject` can now scaffold projects from CogSol Cookbook templates and examples via `--from-template` / `--from-example`, with `--list-templates` / `--list-examples` to browse available entries. Supports custom cookbook repositories (`--cookbook-repo`) and private repos (`--github-token`).
+- `BaseRetrievalTool.filters`: searches can now declare metadata filters (by metadata config name, `topic/name`, or `BaseMetadataConfig` subclass). `migrate` resolves them to Cognitive filter definitions (`metadata_config_id`, type, possible values, format) and assigns them to the search.
+- `editmcptools` and `deletemcptools` commands for editing/removing MCP servers and their tools (updates classes, `.env` vars, and Cognitive without duplications).
+- `importagent` now also imports MCP servers/tools, topic metadata configs (`data/<topic>/metadata.py`), and search filters (collapsing date filter triplets into a single metadata reference).
+
+- `BaseAgent.Meta.alias`: assistant alias shown in the chat UI (Cognitive `info` field). `startagent` template now documents all personalization Meta fields.
+
+### Fixed
+- `startproject --from-template/--from-example` no longer fails for entries pushed to the cookbook repo after the tarball was cached: on "not found" the cache is refreshed once and the fetch retried (branch/tag refs only — SHA refs are immutable). The error message now includes `repo@ref` and lists the available entries of that kind.
+- `makemigrations`/`migrate` no longer fail when tool code imports packages that only exist in the Cognitive runtime (e.g. `django`): missing third-party imports are stubbed during definition collection with a warning. Project-local import errors still fail loudly.
+- Agent personalization colors are now written with the camelCase keys the chat frontend actually reads (`nameColor`, `primaryColor`, `secondaryColor`, `borderColor`) instead of unused snake_case keys, and `info` is populated from `Meta.alias` instead of always being `None`.
+- `importagent` now imports the assistant's personalization (alias/`info` and colors) into the generated `Meta`, accepting both camelCase and legacy snake_case color keys.
+- `migrate` no longer wipes filters assigned to a search in the portal: the retrieval tool payload now always includes the `filters` resolved from the class definition.
+- `importagent` handles MCP `server` references returned as strings or nested dicts, and no longer skips generating classes when the template file contains commented-out examples with the same class name.
 
 ---
 

--- a/cogsol/agents/__init__.py
+++ b/cogsol/agents/__init__.py
@@ -47,7 +47,10 @@ class BaseAgent:
     class Meta:
         name: str | None = None
         chat_name: str | None = None
+        # Alias shown in the chat UI (Cognitive "info" field).
+        alias: str | None = None
         logo_url: str | None = None
+        # Chat personalization colors (hex strings, e.g. "#1A3C5E").
         assistant_name_color: str | None = None
         primary_color: str | None = None
         secondary_color: str | None = None

--- a/cogsol/core/api.py
+++ b/cogsol/core/api.py
@@ -464,6 +464,10 @@ class CogSolClient:
             {"selected_tools": selected_tools},
         )
 
+    def get_mcp_tool(self, tool_id: int) -> Any:
+        """Get an MCP tool by id."""
+        return self.request("GET", f"/mcp-tools/{tool_id}/")
+
     def delete_mcp_tool(self, tool_id: int) -> None:
         """Delete an MCP tool by id."""
         self.request("DELETE", f"/mcp-tools/{tool_id}/")

--- a/cogsol/core/cookbook.py
+++ b/cogsol/core/cookbook.py
@@ -69,7 +69,12 @@ def _cache_is_fresh(path: Path, ref: str) -> bool:
     return age < CACHE_TTL_SECONDS
 
 
-def _download_tarball(repo: str, ref: str, github_token: str | None = None) -> Path:
+def _download_tarball(
+    repo: str,
+    ref: str,
+    github_token: str | None = None,
+    force_refresh: bool = False,
+) -> Path:
     """Download the repo tarball and cache it. Returns path to the .tar.gz."""
     tarballs_dir = CACHE_DIR / "tarballs"
     tarballs_dir.mkdir(parents=True, exist_ok=True)
@@ -78,7 +83,7 @@ def _download_tarball(repo: str, ref: str, github_token: str | None = None) -> P
     ref_slug = ref.replace("/", "--")
     cache_path = tarballs_dir / f"{slug}-{ref_slug}.tar.gz"
 
-    if _cache_is_fresh(cache_path, ref):
+    if not force_refresh and _cache_is_fresh(cache_path, ref):
         return cache_path
 
     url = TARBALL_URL.format(repo=repo, ref=ref)
@@ -231,9 +236,26 @@ def fetch_cookbook_directory(
         Path to the extracted directory.
     """
     repo = repo or DEFAULT_REPO
-    tarball_path = _download_tarball(repo, ref, github_token=github_token)
     prefix = f"{kind.rstrip('/')}/{name}"
-    return _extract_subdirectory(tarball_path, prefix)
+    tarball_path = _download_tarball(repo, ref, github_token=github_token)
+    try:
+        return _extract_subdirectory(tarball_path, prefix)
+    except CookbookError as exc:
+        # The entry may have been pushed to the repo after the tarball was
+        # cached (branch/tag refs are cached for up to an hour). Refresh the
+        # cache once and retry before giving up. SHA refs are immutable, so
+        # a refresh cannot change the outcome.
+        if _is_sha(ref) or "not found" not in str(exc):
+            raise
+        tarball_path = _download_tarball(
+            repo, ref, github_token=github_token, force_refresh=True
+        )
+        try:
+            return _extract_subdirectory(tarball_path, prefix)
+        except CookbookError as exc2:
+            if "not found" in str(exc2):
+                raise CookbookError(f"'{prefix}' not found in {repo}@{ref}.") from exc2
+            raise
 
 
 def materialize_cookbook(source_dir: Path, target_dir: Path, force: bool = False) -> None:

--- a/cogsol/core/cookbook.py
+++ b/cogsol/core/cookbook.py
@@ -247,9 +247,7 @@ def fetch_cookbook_directory(
         # a refresh cannot change the outcome.
         if _is_sha(ref) or "not found" not in str(exc):
             raise
-        tarball_path = _download_tarball(
-            repo, ref, github_token=github_token, force_refresh=True
-        )
+        tarball_path = _download_tarball(repo, ref, github_token=github_token, force_refresh=True)
         try:
             return _extract_subdirectory(tarball_path, prefix)
         except CookbookError as exc2:

--- a/cogsol/core/loader.py
+++ b/cogsol/core/loader.py
@@ -136,7 +136,7 @@ class _MissingDependencyStubber(importlib.abc.MetaPathFinder, importlib.abc.Load
 
     def _is_stubbable(self, fullname: str) -> bool:
         top = fullname.split(".")[0]
-        stdlib_names = getattr(sys, "stdlib_module_names", frozenset())
+        stdlib_names: frozenset[str] = getattr(sys, "stdlib_module_names", frozenset())
         if top == "cogsol" or top in stdlib_names:
             return False
         # Never stub project-local modules — a typo there is a real error.

--- a/cogsol/core/loader.py
+++ b/cogsol/core/loader.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 
 import ast
 import importlib
+import importlib.abc
+import importlib.machinery
 import inspect
 import sys
 import textwrap
+import types
 from enum import Enum
 from pathlib import Path
 from typing import Any, Union, cast
@@ -98,24 +101,128 @@ def serialize_value(value: Any) -> Any:
     return repr(value)
 
 
-def _import_module(module_name: str, project_path: Path):
-    # Ensure project modules are reloaded from the current project path.
+class _StubValue:
+    """Inert placeholder for attributes of packages that are not installed locally."""
+
+    def __init__(self, name: str) -> None:
+        self._stub_name = name
+
+    def __getattr__(self, item: str) -> "_StubValue":
+        return _StubValue(f"{self._stub_name}.{item}")
+
+    def __call__(self, *args: Any, **kwargs: Any) -> "_StubValue":
+        return _StubValue(f"{self._stub_name}()")
+
+    def __repr__(self) -> str:
+        return f"<stubbed missing dependency {self._stub_name}>"
+
+
+class _MissingDependencyStubber(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Fabricates inert stub modules for packages not installed locally.
+
+    Tool ``run()`` code executes remotely in Cognitive, where its imports are
+    available. Locally we only need the class *definitions*, so module-level
+    imports of missing third-party packages (e.g. ``django``) are satisfied
+    with stubs while collecting definitions.
+
+    The finder is appended at the END of ``sys.meta_path``, so installed
+    packages always resolve normally; only genuinely missing ones are stubbed.
+    """
+
+    def __init__(self, project_path: Path) -> None:
+        self.project_path = project_path
+        self.stubbed_roots: set[str] = set()
+        self.created_modules: list[str] = []
+
+    def _is_stubbable(self, fullname: str) -> bool:
+        top = fullname.split(".")[0]
+        stdlib_names = getattr(sys, "stdlib_module_names", frozenset())
+        if top == "cogsol" or top in stdlib_names:
+            return False
+        # Never stub project-local modules — a typo there is a real error.
+        if (self.project_path / top).exists() or (self.project_path / f"{top}.py").exists():
+            return False
+        return True
+
+    def find_spec(self, fullname, path=None, target=None):
+        if not self._is_stubbable(fullname):
+            return None
+        return importlib.machinery.ModuleSpec(fullname, self, is_package=True)
+
+    def create_module(self, spec):
+        module = types.ModuleType(spec.name)
+        module.__path__ = []  # behave as a package so submodule imports resolve too
+        module.__getattr__ = lambda item, _n=spec.name: _StubValue(f"{_n}.{item}")
+        self.stubbed_roots.add(spec.name.split(".")[0])
+        self.created_modules.append(spec.name)
+        return module
+
+    def exec_module(self, module):
+        return None
+
+
+def _purge_module_cache(module_name: str) -> None:
     parts = module_name.split(".")
     for i in range(1, len(parts) + 1):
-        mod_name = ".".join(parts[:i])
-        sys.modules.pop(mod_name, None)
+        sys.modules.pop(".".join(parts[:i]), None)
     for name in list(sys.modules):
         if name.startswith(f"{module_name}."):
             sys.modules.pop(name, None)
+
+
+def _import_module(module_name: str, project_path: Path):
+    # Ensure project modules are reloaded from the current project path.
+    _purge_module_cache(module_name)
     sys.path.insert(0, str(project_path))
     try:
         importlib.invalidate_caches()
-        return importlib.import_module(module_name)
+        try:
+            return importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            missing_root = (exc.name or "").split(".")[0]
+            target_root = module_name.split(".")[0]
+            # Only stub genuinely foreign packages. If the project module
+            # itself (or another project-local module) is missing, keep the
+            # original error so callers can handle/report it.
+            if (
+                not missing_root
+                or missing_root == target_root
+                or missing_root == "cogsol"
+                or (project_path / missing_root).exists()
+                or (project_path / f"{missing_root}.py").exists()
+            ):
+                raise
+            return _import_module_with_stubs(module_name, project_path)
     finally:
         try:
             sys.path.remove(str(project_path))
         except ValueError:
             pass
+
+
+def _import_module_with_stubs(module_name: str, project_path: Path):
+    """Retry a project-module import stubbing missing third-party packages."""
+    _purge_module_cache(module_name)
+    finder = _MissingDependencyStubber(project_path)
+    sys.meta_path.append(finder)
+    try:
+        importlib.invalidate_caches()
+        module = importlib.import_module(module_name)
+    finally:
+        try:
+            sys.meta_path.remove(finder)
+        except ValueError:
+            pass
+        # Drop fabricated modules so they never shadow real installs later.
+        for name in finder.created_modules:
+            sys.modules.pop(name, None)
+    if finder.stubbed_roots:
+        missing = ", ".join(sorted(finder.stubbed_roots))
+        print(
+            f"  Warning: '{module_name}' imports packages not installed locally: {missing}. "
+            "They were stubbed to collect definitions — this code still runs in Cognitive."
+        )
+    return module
 
 
 def _ignore_missing_module(exc: ModuleNotFoundError, module_name: str) -> bool:

--- a/cogsol/core/loader.py
+++ b/cogsol/core/loader.py
@@ -107,10 +107,10 @@ class _StubValue:
     def __init__(self, name: str) -> None:
         self._stub_name = name
 
-    def __getattr__(self, item: str) -> "_StubValue":
+    def __getattr__(self, item: str) -> _StubValue:
         return _StubValue(f"{self._stub_name}.{item}")
 
-    def __call__(self, *args: Any, **kwargs: Any) -> "_StubValue":
+    def __call__(self, *args: Any, **kwargs: Any) -> _StubValue:
         return _StubValue(f"{self._stub_name}()")
 
     def __repr__(self) -> str:

--- a/cogsol/core/management.py
+++ b/cogsol/core/management.py
@@ -24,6 +24,8 @@ def _command_registry() -> dict[str, str]:
         "makemigrations": "cogsol.management.commands.makemigrations",
         "migrate": "cogsol.management.commands.migrate",
         "addmcptools": "cogsol.management.commands.addmcptools",
+        "editmcptools": "cogsol.management.commands.editmcptools",
+        "deletemcptools": "cogsol.management.commands.deletemcptools",
         "chat": "cogsol.management.commands.chat",
     }
 

--- a/cogsol/management/commands/addmcptools.py
+++ b/cogsol/management/commands/addmcptools.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from cogsol.core.api import CogSolAPIError, CogSolClient
+from cogsol.core.constants import get_cognitive_api_base_url
 from cogsol.core.mcp import MCPClient
 from cogsol.management.base import BaseCommand
 
@@ -241,7 +242,7 @@ class Command(BaseCommand):
         oauth_scopes: str,
         oauth_timeout: int,
     ) -> list[dict[str, Any]]:
-        api_base = os.environ.get("COGSOL_API_BASE")
+        api_base = get_cognitive_api_base_url()
         api_key = os.environ.get("COGSOL_API_KEY")
         if not api_base:
             print("COGSOL_API_BASE is required to run assisted OAuth tool discovery.")
@@ -341,13 +342,8 @@ class Command(BaseCommand):
         selected_tools: list[dict[str, Any]],
         oauth_timeout: int,
     ) -> None:
-        api_base = os.environ.get("COGSOL_API_BASE")
+        api_base = get_cognitive_api_base_url()
         api_key = os.environ.get("COGSOL_API_KEY")
-        if not api_base:
-            raise CogSolAPIError(
-                "COGSOL_API_BASE is required. addmcptools now publishes MCP servers/tools "
-                "directly to Cognitive."
-            )
 
         client = CogSolClient(base_url=api_base, api_key=api_key)
         existing = self._find_remote_server(

--- a/cogsol/management/commands/deletemcptools.py
+++ b/cogsol/management/commands/deletemcptools.py
@@ -1,0 +1,317 @@
+"""Interactive command for removing an MCP server and its tool definitions.
+
+Workflow
+--------
+1.  List MCP server classes defined in ``agents/mcp_servers.py``.
+2.  User selects a server to remove.
+3.  All tool classes in ``agents/mcp_tools.py`` that reference that server
+    are shown for confirmation.
+4.  On confirmation:
+    - Deletes the server from the CogSol API.
+    - Removes the server class from ``mcp_servers.py``.
+    - Removes the associated tool classes from ``mcp_tools.py``.
+    - Removes the related env vars from ``.env``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from cogsol.core.api import CogSolAPIError, CogSolClient
+from cogsol.core.constants import get_cognitive_api_base_url
+from cogsol.core.loader import collect_classes
+from cogsol.management.base import BaseCommand
+from cogsol.management.commands.addmcptools import (
+    _ask,
+    _ask_yes_no,
+    _to_env_key,
+)
+
+
+def _remove_class_from_source(source: str, class_name: str) -> tuple[str, bool]:
+    """Remove a top-level class definition from Python source using AST.
+
+    Returns ``(new_source, was_removed)``.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source, False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            lines = source.splitlines(keepends=True)
+            start = node.lineno - 1  # 0-based index
+            end = node.end_lineno  # 0-based exclusive end
+
+            # Also remove blank lines immediately before the class.
+            while start > 0 and lines[start - 1].strip() == "":
+                start -= 1
+
+            return "".join(lines[:start] + lines[end:]), True
+
+    return source, False
+
+
+def _find_server_env_prefix(server_name: str) -> str:
+    """Return the env-var prefix used for *server_name* (e.g. 'MCP_MY_SERVER_')."""
+    return _to_env_key(server_name) + "_"
+
+
+def _collect_server_env_keys(env_path: Path, prefix: str) -> set[str]:
+    """Return all env-var keys in *env_path* that start with *prefix*."""
+    if not env_path.exists():
+        return set()
+    result: set[str] = set()
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key.startswith(prefix):
+                result.add(key)
+    return result
+
+
+def _remove_env_keys(env_path: Path, keys: set[str]) -> int:
+    """Remove env var lines (and orphaned section comments) from *.env*.
+
+    Returns the number of variable lines removed.
+    """
+    if not env_path.exists() or not keys:
+        return 0
+
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    out: list[str] = []
+    removed = 0
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Check if this is a "# MCP Server: ..." comment whose entire block
+        # is being removed — if so, skip the comment too.
+        if stripped.startswith("#") and "MCP Server:" in stripped:
+            j = i + 1
+            block_keys: list[str] = []
+            while j < len(lines):
+                nxt = lines[j].strip()
+                if not nxt or nxt.startswith("#"):
+                    break
+                if "=" in nxt:
+                    block_keys.append(nxt.split("=", 1)[0].strip())
+                j += 1
+            if block_keys and all(k in keys for k in block_keys):
+                # Skip the comment and its whole block.
+                i = j
+                removed += len(block_keys)
+                continue
+
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip()
+            if key in keys:
+                removed += 1
+                i += 1
+                continue
+
+        out.append(line)
+        i += 1
+
+    env_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+    return removed
+
+
+class Command(BaseCommand):
+    help = "Remove an MCP server and its tool definitions from the project."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--app",
+            default="agents",
+            help="App folder (default: agents).",
+        )
+
+    def handle(self, project_path: Path | None, **options: Any) -> int:
+        assert project_path is not None, "project_path is required"
+        app = str(options.get("app") or "agents")
+
+        if not self.ensure_credentials_configured(project_path):
+            return 1
+
+        # ── Load local MCP definitions ────────────────────────────────
+        try:
+            classes = collect_classes(project_path, app)
+        except Exception as exc:
+            print(f"Could not load MCP definitions: {exc}")
+            return 1
+
+        servers: dict[str, Any] = classes.get("mcp_servers", {})
+        if not servers:
+            print("No MCP server definitions found in this project.")
+            return 0
+
+        server_names = sorted(servers.keys())
+        print("\nAvailable MCP servers:\n")
+        for i, name in enumerate(server_names, 1):
+            cls = servers[name]
+            url = getattr(cls, "url", "") or ""
+            auth = getattr(cls, "auth_type", "headers")
+            print(f"  {i}. {name}  ({url})  [{auth}]")
+        print()
+
+        choice = _ask("Select server to delete (number, or 0 to cancel)", "0")
+        if choice == "0" or not choice:
+            print("Cancelled.")
+            return 0
+
+        try:
+            idx = int(choice) - 1
+            if idx < 0 or idx >= len(server_names):
+                raise ValueError
+        except ValueError:
+            print("Invalid selection.")
+            return 1
+
+        server_key = server_names[idx]
+        server_cls = servers[server_key]
+        server_real_name: str = getattr(server_cls, "name", None) or server_key
+
+        # ── Find tools that belong to this server ─────────────────────
+        all_tools: dict[str, Any] = classes.get("mcp_tools", {})
+        server_tools = {
+            name: cls
+            for name, cls in all_tools.items()
+            if (
+                getattr(cls, "server", None) is server_cls
+                or getattr(getattr(cls, "server", None), "__name__", None)
+                == server_cls.__name__
+            )
+        }
+
+        # ── Summary & confirmation ────────────────────────────────────
+        print(f"\nWill delete:")
+        print(f"  Server : {server_real_name}  (class: {server_cls.__name__})")
+        if server_tools:
+            tool_list = ", ".join(sorted(server_tools.keys()))
+            print(f"  Tools  : {tool_list}")
+        else:
+            print("  Tools  : none")
+        print()
+
+        if not _ask_yes_no("Confirm deletion?", default=False):
+            print("Cancelled.")
+            return 0
+
+        # ── Delete from CogSol API ────────────────────────────────────
+        api_base = get_cognitive_api_base_url()
+        api_key = os.environ.get("COGSOL_API_KEY")
+        if api_base:
+            client = CogSolClient(base_url=api_base, api_key=api_key)
+            # Find remote server by name (same approach as addmcptools)
+            try:
+                servers_remote = client.list_mcp_servers()
+                results = (
+                    servers_remote
+                    if isinstance(servers_remote, list)
+                    else (servers_remote or {}).get("results", [])
+                )
+                server_url = getattr(server_cls, "url", "") or ""
+                remote_entry = next(
+                    (
+                        s
+                        for s in results
+                        if isinstance(s, dict)
+                        and (
+                            str(s.get("name", "")).strip().casefold()
+                            == server_real_name.strip().casefold()
+                            or str(s.get("url", "")).rstrip("/")
+                            == str(server_url).rstrip("/")
+                        )
+                    ),
+                    None,
+                )
+                if remote_entry and remote_entry.get("id"):
+                    client.delete_mcp_server(int(remote_entry["id"]))
+                    print(f"  Deleted MCP server from Cognitive (id={remote_entry['id']}).")
+                else:
+                    print(
+                        "  Warning: MCP server not found in Cognitive; skipping API deletion."
+                    )
+            except CogSolAPIError as exc:
+                print(f"  Warning: could not delete server from API: {exc}")
+        else:
+            print("  COGSOL_API_BASE not set — skipping API deletion.")
+
+        # ── Remove server class from mcp_servers.py ──────────────────
+        servers_file = project_path / app / "mcp_servers.py"
+        if servers_file.exists():
+            source = servers_file.read_text(encoding="utf-8")
+            new_source, removed = _remove_class_from_source(source, server_cls.__name__)
+            if removed:
+                servers_file.write_text(new_source, encoding="utf-8")
+                print(f"  Removed {server_cls.__name__} from mcp_servers.py")
+            else:
+                print(
+                    f"  Warning: {server_cls.__name__} not found in mcp_servers.py"
+                )
+
+        # ── Remove tool classes from mcp_tools.py ────────────────────
+        tools_file = project_path / app / "mcp_tools.py"
+        if tools_file.exists() and server_tools:
+            source = tools_file.read_text(encoding="utf-8")
+            for tool_name, tool_cls in server_tools.items():
+                new_source, removed = _remove_class_from_source(source, tool_cls.__name__)
+                if removed:
+                    source = new_source
+                    print(f"  Removed {tool_cls.__name__} from mcp_tools.py")
+
+            # Remove the import line referencing this server class.
+            import_line = f"from {app}.mcp_servers import {server_cls.__name__}"
+            source = source.replace(import_line + "\n", "").replace(import_line, "")
+            tools_file.write_text(source, encoding="utf-8")
+
+        # ── Clean .env ────────────────────────────────────────────────
+        env_path = project_path / ".env"
+        prefix = _find_server_env_prefix(server_real_name)
+        keys_to_remove = _collect_server_env_keys(env_path, prefix)
+        if keys_to_remove:
+            count = _remove_env_keys(env_path, keys_to_remove)
+            print(f"  Removed {count} env var(s) from .env")
+        else:
+            print("  No env vars found to remove.")
+
+        # ── Update .state.json ────────────────────────────────────────
+        state_path = project_path / app / "migrations" / ".state.json"
+        if state_path.exists():
+            try:
+                state: dict[str, Any] = json.loads(state_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                state = {}
+
+            remote = state.get("remote", {})
+            mcp_srv = remote.get("mcp_servers", {})
+            for k in list(mcp_srv.keys()):
+                if k in (server_key, server_real_name, server_cls.__name__):
+                    del mcp_srv[k]
+
+            mcp_tools_remote = remote.get("mcp_tools", {})
+            for tool_name in server_tools:
+                mcp_tools_remote.pop(tool_name, None)
+
+            local_state = state.get("state", {})
+            local_state.get("mcp_servers", {}).pop(server_key, None)
+            for tool_name in server_tools:
+                local_state.get("mcp_tools", {}).pop(tool_name, None)
+
+            state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            print("  Updated .state.json")
+
+        print(
+            "\nDone! Run 'python manage.py makemigrations' followed by "
+            "'python manage.py migrate' to apply the deletion."
+        )
+        return 0

--- a/cogsol/management/commands/deletemcptools.py
+++ b/cogsol/management/commands/deletemcptools.py
@@ -186,8 +186,7 @@ class Command(BaseCommand):
             for name, cls in all_tools.items()
             if (
                 getattr(cls, "server", None) is server_cls
-                or getattr(getattr(cls, "server", None), "__name__", None)
-                == server_cls.__name__
+                or getattr(getattr(cls, "server", None), "__name__", None) == server_cls.__name__
             )
         }
 
@@ -227,8 +226,7 @@ class Command(BaseCommand):
                         and (
                             str(s.get("name", "")).strip().casefold()
                             == server_real_name.strip().casefold()
-                            or str(s.get("url", "")).rstrip("/")
-                            == str(server_url).rstrip("/")
+                            or str(s.get("url", "")).rstrip("/") == str(server_url).rstrip("/")
                         )
                     ),
                     None,
@@ -237,9 +235,7 @@ class Command(BaseCommand):
                     client.delete_mcp_server(int(remote_entry["id"]))
                     print(f"  Deleted MCP server from Cognitive (id={remote_entry['id']}).")
                 else:
-                    print(
-                        "  Warning: MCP server not found in Cognitive; skipping API deletion."
-                    )
+                    print("  Warning: MCP server not found in Cognitive; skipping API deletion.")
             except CogSolAPIError as exc:
                 print(f"  Warning: could not delete server from API: {exc}")
         else:
@@ -254,9 +250,7 @@ class Command(BaseCommand):
                 servers_file.write_text(new_source, encoding="utf-8")
                 print(f"  Removed {server_cls.__name__} from mcp_servers.py")
             else:
-                print(
-                    f"  Warning: {server_cls.__name__} not found in mcp_servers.py"
-                )
+                print(f"  Warning: {server_cls.__name__} not found in mcp_servers.py")
 
         # ── Remove tool classes from mcp_tools.py ────────────────────
         tools_file = project_path / app / "mcp_tools.py"

--- a/cogsol/management/commands/deletemcptools.py
+++ b/cogsol/management/commands/deletemcptools.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import ast
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
@@ -193,7 +192,7 @@ class Command(BaseCommand):
         }
 
         # ── Summary & confirmation ────────────────────────────────────
-        print(f"\nWill delete:")
+        print("\nWill delete:")
         print(f"  Server : {server_real_name}  (class: {server_cls.__name__})")
         if server_tools:
             tool_list = ", ".join(sorted(server_tools.keys()))
@@ -263,7 +262,7 @@ class Command(BaseCommand):
         tools_file = project_path / app / "mcp_tools.py"
         if tools_file.exists() and server_tools:
             source = tools_file.read_text(encoding="utf-8")
-            for tool_name, tool_cls in server_tools.items():
+            for tool_cls in server_tools.values():
                 new_source, removed = _remove_class_from_source(source, tool_cls.__name__)
                 if removed:
                     source = new_source

--- a/cogsol/management/commands/editmcptools.py
+++ b/cogsol/management/commands/editmcptools.py
@@ -1,0 +1,922 @@
+"""Interactive command for editing an existing MCP server configuration.
+
+Workflow
+--------
+1.  List MCP server classes defined in ``agents/mcp_servers.py``.
+2.  User selects a server to edit.
+3.  Re-prompt for server details (name, description, URL, auth type,
+    credentials) — current values are shown as defaults.
+4.  Reconnect to the MCP server and re-discover tools.
+5.  User selects which tools to keep.
+6.  Remove the old server class (and its tools) from the source files.
+7.  Append the updated class definitions.
+8.  Update ``.env`` — rename prefix if the server name changed, and
+    update/add only the changed credential vars.
+9.  PATCH the server in the CogSol API and re-sync its tools.
+
+Notes
+-----
+If the server name changes, the class name, env-var prefix, import line,
+and ``server =`` attribute in tool classes are all updated to match.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import time
+import webbrowser
+from getpass import getpass
+from pathlib import Path
+from typing import Any
+
+from cogsol.core.api import CogSolAPIError, CogSolClient
+from cogsol.core.constants import get_cognitive_api_base_url
+from cogsol.core.loader import collect_classes
+from cogsol.core.mcp import MCPClient
+from cogsol.management.base import BaseCommand
+from cogsol.management.commands.addmcptools import (
+    AUTH_TYPES,
+    HEADER_KEYS,
+    OAUTH_POLL_INTERVAL_SECONDS,
+    OAUTH_POLL_SECONDS_DEFAULT,
+    _ask,
+    _ask_secret,
+    _ask_yes_no,
+    _oauth_config,
+    _py_str,
+    _to_env_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# File-manipulation helpers
+# ---------------------------------------------------------------------------
+
+
+def _remove_class_from_source(source: str, class_name: str) -> tuple[str, bool]:
+    """Remove a top-level class definition using AST line ranges.
+
+    Returns ``(new_source, was_removed)``.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source, False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            lines = source.splitlines(keepends=True)
+            start = node.lineno - 1  # 0-based
+            end = node.end_lineno  # 0-based exclusive
+
+            while start > 0 and lines[start - 1].strip() == "":
+                start -= 1
+
+            return "".join(lines[:start] + lines[end:]), True
+
+    return source, False
+
+
+def _read_env_vars(env_path: Path) -> dict[str, str]:
+    if not env_path.exists():
+        return {}
+    result: dict[str, str] = {}
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            k, _, v = stripped.partition("=")
+            result[k.strip()] = v.strip()
+    return result
+
+
+def _update_env_file(
+    env_path: Path,
+    *,
+    remove_keys: set[str],
+    update: dict[str, str],
+    section_comment: str = "",
+) -> None:
+    """Atomically update a .env file.
+
+    - Removes lines whose key is in *remove_keys*.
+    - Updates the value of existing keys found in *update*.
+    - Appends any remaining keys from *update* that weren't already in the file.
+    """
+    lines: list[str] = []
+    if env_path.exists():
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+
+    # Pass 1: drop removed keys and orphaned section comment for those keys.
+    filtered: list[str] = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("#") and "MCP Server:" in stripped:
+            j = i + 1
+            block_keys: list[str] = []
+            while j < len(lines):
+                nxt = lines[j].strip()
+                if not nxt or nxt.startswith("#"):
+                    break
+                if "=" in nxt:
+                    block_keys.append(nxt.split("=", 1)[0].strip())
+                j += 1
+            if block_keys and all(k in remove_keys for k in block_keys):
+                i = j
+                continue
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip()
+            if key in remove_keys:
+                i += 1
+                continue
+        filtered.append(lines[i])
+        i += 1
+
+    # Pass 2: update existing values in-place.
+    written: set[str] = set()
+    out: list[str] = []
+    for line in filtered:
+        stripped = line.strip()
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip()
+            if key in update:
+                out.append(f"{key}={update[key]}")
+                written.add(key)
+                continue
+        out.append(line)
+
+    # Pass 3: append new keys.
+    additions = {k: v for k, v in update.items() if k not in written}
+    if additions:
+        out.append("")
+        if section_comment:
+            out.append(f"# MCP Server: {section_comment}")
+        out.extend(f"{k}={v}" for k, v in additions.items())
+
+    env_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# OAuth helpers (re-used from addmcptools flow)
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_oauth_connected(
+    *, client: CogSolClient, server_id: int, timeout_seconds: int
+) -> bool:
+    start = time.time()
+    while time.time() - start < timeout_seconds:
+        try:
+            data = client.get_mcp_server(server_id) or {}
+            if str(data.get("oauth_status", "")).lower() == "connected":
+                return True
+        except CogSolAPIError:
+            pass
+        time.sleep(OAUTH_POLL_INTERVAL_SECONDS)
+    return False
+
+
+def _is_oauth_reauth_error(exc: CogSolAPIError) -> bool:
+    return "oauth re-authorization required" in str(exc).lower()
+
+
+def _is_oauth_required_error(exc: CogSolAPIError) -> bool:
+    """True when the API says the MCP server needs OAuth before serving tools."""
+    text = str(exc).lower()
+    return (
+        "mcp_oauth_required" in text
+        or "network authentication required" in text
+        or "oauth re-authorization required" in text
+    )
+
+
+def _start_oauth_authorization(
+    *, client: CogSolClient, server_id: int, server_name: str, timeout: int
+) -> None:
+    auth_payload = client.get_mcp_oauth_authorization_url(server_id) or {}
+    url = auth_payload.get("authorization_url")
+    if not url:
+        raise CogSolAPIError(
+            f"OAuth authorization URL could not be generated for '{server_name}'."
+        )
+    if not webbrowser.open(str(url), new=1, autoraise=True):
+        print(f"  Open this URL manually: {url}")
+    if not _wait_for_oauth_connected(
+        client=client, server_id=server_id, timeout_seconds=max(5, timeout)
+    ):
+        raise CogSolAPIError(
+            "OAuth authorization did not complete within timeout. "
+            "Re-run editmcptools after finishing OAuth in the browser."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Command
+# ---------------------------------------------------------------------------
+
+
+class Command(BaseCommand):
+    help = "Interactively edit an existing MCP server configuration and its tools."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--app", default="agents", help="App folder (default: agents).")
+        parser.add_argument(
+            "--oauth-timeout",
+            default=OAUTH_POLL_SECONDS_DEFAULT,
+            type=int,
+            help="Seconds to wait for OAuth completion.",
+        )
+
+    def _find_remote_server(
+        self,
+        *,
+        client: CogSolClient,
+        server_name: str,
+        server_url: str,
+    ) -> dict[str, Any] | None:
+        norm = lambda s: re.sub(r"\s+", " ", str(s or "")).strip().casefold()
+        try:
+            payload = client.list_mcp_servers()
+            results = payload if isinstance(payload, list) else (payload or {}).get("results", [])
+        except CogSolAPIError:
+            return None
+
+        name_n = norm(server_name)
+        url_n = norm(str(server_url).rstrip("/"))
+
+        exact = [
+            s
+            for s in results
+            if isinstance(s, dict)
+            and norm(s.get("name")) == name_n
+            and norm(str(s.get("url", "")).rstrip("/")) == url_n
+        ]
+        if exact:
+            return exact[0]
+
+        by_name = [s for s in results if isinstance(s, dict) and norm(s.get("name")) == name_n]
+        if len(by_name) == 1:
+            return by_name[0]
+
+        by_url = [
+            s
+            for s in results
+            if isinstance(s, dict) and norm(str(s.get("url", "")).rstrip("/")) == url_n
+        ]
+        if len(by_url) >= 1:
+            by_url.sort(
+                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
+                reverse=True,
+            )
+            return by_url[0]
+
+        if len(by_name) > 1:
+            by_name.sort(
+                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
+                reverse=True,
+            )
+            return by_name[0]
+
+        return None
+
+    def _discover_tools_via_api(
+        self,
+        *,
+        old_server_name: str,
+        old_server_url: str,
+        server_name: str,
+        server_url: str,
+        oauth_timeout: int,
+    ) -> list[dict[str, Any]]:
+        """Discover tools through the Cognitive API (backend holds OAuth tokens).
+
+        Used when a direct MCP connection is not possible (e.g. Cloudflare
+        blocks non-browser clients, or the server requires OAuth).
+        """
+        api_base = get_cognitive_api_base_url()
+        api_key = os.environ.get("COGSOL_API_KEY")
+        client = CogSolClient(base_url=api_base, api_key=api_key)
+
+        remote = self._find_remote_server(
+            client=client, server_name=old_server_name, server_url=old_server_url
+        ) or self._find_remote_server(
+            client=client, server_name=server_name, server_url=server_url
+        )
+        if not remote or not remote.get("id"):
+            print("  Server not found in Cognitive; cannot discover tools via API.")
+            return []
+        server_id = int(remote["id"])
+
+        def _list_tools() -> list[dict[str, Any]]:
+            payload = client.list_mcp_server_tools(server_id)
+            if isinstance(payload, list):
+                items = payload
+            elif isinstance(payload, dict):
+                items = next(
+                    (
+                        payload[k]
+                        for k in ("results", "configured_tools", "tools")
+                        if isinstance(payload.get(k), list)
+                    ),
+                    [],
+                )
+            else:
+                items = []
+            return [
+                {
+                    "name": str(t.get("name")),
+                    "description": str(t.get("description") or ""),
+                }
+                for t in items
+                if isinstance(t, dict) and t.get("name")
+            ]
+
+        try:
+            return _list_tools()
+        except CogSolAPIError as exc:
+            if not _is_oauth_required_error(exc):
+                print(f"  Could not list tools via Cognitive API: {exc}")
+                return []
+            print("  OAuth authorization required — starting browser flow...")
+            try:
+                try:
+                    client.discover_mcp_oauth(server_id)
+                except CogSolAPIError:
+                    pass
+                _start_oauth_authorization(
+                    client=client,
+                    server_id=server_id,
+                    server_name=old_server_name,
+                    timeout=oauth_timeout,
+                )
+                return _list_tools()
+            except CogSolAPIError as exc2:
+                print(f"  OAuth-assisted discovery failed: {exc2}")
+                return []
+
+    def _publish_update(
+        self,
+        *,
+        server_name: str,
+        server_description: str,
+        server_url: str,
+        auth_type: str,
+        headers: dict[str, str],
+        oauth_client_id: str,
+        oauth_client_secret: str,
+        oauth_scopes: str,
+        selected_tools: list[dict[str, Any]],
+        old_server_name: str,
+        old_server_url: str,
+        oauth_timeout: int,
+    ) -> None:
+        api_base = get_cognitive_api_base_url()
+        api_key = os.environ.get("COGSOL_API_KEY")
+
+        client = CogSolClient(base_url=api_base, api_key=api_key)
+
+        # Look up by old name/url first, then new.
+        existing = self._find_remote_server(
+            client=client, server_name=old_server_name, server_url=old_server_url
+        )
+        if existing is None:
+            existing = self._find_remote_server(
+                client=client, server_name=server_name, server_url=server_url
+            )
+        remote_id = int(existing["id"]) if existing and existing.get("id") else None
+
+        payload: dict[str, Any] = {
+            "name": server_name,
+            "description": server_description,
+            "url": server_url,
+            "protocol_version": "2025-03-26",
+            "client_name": "cognitive-mcp-client",
+            "client_version": "1.0.0",
+            "active": True,
+            "auth_type": auth_type,
+        }
+        if auth_type == "headers":
+            if headers:
+                payload["headers"] = headers
+        else:
+            payload["headers"] = {}
+        if auth_type == "oauth2":
+            payload["oauth_config"] = _oauth_config(oauth_client_id, oauth_scopes)
+            if oauth_client_secret:
+                payload["oauth_client_secret"] = oauth_client_secret
+
+        server_id = int(client.upsert_mcp_server(remote_id=remote_id, payload=payload))
+        action = "Updated" if remote_id else "Created"
+        print(f"  {action} MCP server in Cognitive (id={server_id}).")
+
+        if auth_type == "oauth2":
+            force_auth = False
+            try:
+                client.discover_mcp_oauth(server_id)
+            except CogSolAPIError as exc:
+                if _is_oauth_reauth_error(exc):
+                    force_auth = True
+                else:
+                    raise
+            server_data = client.get_mcp_server(server_id) or {}
+            if force_auth or str(server_data.get("oauth_status", "")).lower() != "connected":
+                print("  OAuth not connected yet — starting authorization flow...")
+                _start_oauth_authorization(
+                    client=client,
+                    server_id=server_id,
+                    server_name=server_name,
+                    timeout=oauth_timeout,
+                )
+
+        tool_names = [str(t.get("name")) for t in selected_tools if t.get("name")]
+        if not tool_names:
+            print("  No MCP tools selected.")
+            return
+
+        try:
+            client.sync_mcp_server_tools(server_id, tool_names)
+        except CogSolAPIError as exc:
+            if auth_type != "oauth2" or not _is_oauth_reauth_error(exc):
+                raise
+            print("  OAuth re-authorization required during tool sync — retrying...")
+            _start_oauth_authorization(
+                client=client, server_id=server_id, server_name=server_name, timeout=oauth_timeout
+            )
+            client.sync_mcp_server_tools(server_id, tool_names)
+        print(f"  Synced {len(tool_names)} MCP tool(s) in Cognitive.")
+
+    def handle(self, project_path: Path | None, **options: Any) -> int:  # noqa: C901
+        assert project_path is not None, "project_path is required"
+        app = str(options.get("app") or "agents")
+        oauth_timeout = int(options.get("oauth_timeout") or OAUTH_POLL_SECONDS_DEFAULT)
+
+        if not self.ensure_credentials_configured(project_path):
+            return 1
+
+        # ── Load local MCP definitions ────────────────────────────────
+        try:
+            classes = collect_classes(project_path, app)
+        except Exception as exc:
+            print(f"Could not load MCP definitions: {exc}")
+            return 1
+
+        servers: dict[str, Any] = classes.get("mcp_servers", {})
+        if not servers:
+            print("No MCP server definitions found in this project.")
+            return 0
+
+        server_names = sorted(servers.keys())
+        print("\nAvailable MCP servers:\n")
+        for i, name in enumerate(server_names, 1):
+            cls = servers[name]
+            url = getattr(cls, "url", "") or ""
+            auth = getattr(cls, "auth_type", "headers")
+            print(f"  {i}. {name}  ({url})  [{auth}]")
+        print()
+
+        choice = _ask("Select server to edit (number, or 0 to cancel)", "0")
+        if choice == "0" or not choice:
+            print("Cancelled.")
+            return 0
+        try:
+            idx = int(choice) - 1
+            if idx < 0 or idx >= len(server_names):
+                raise ValueError
+        except ValueError:
+            print("Invalid selection.")
+            return 1
+
+        old_server_key = server_names[idx]
+        server_cls = servers[old_server_key]
+
+        old_server_name: str = getattr(server_cls, "name", None) or old_server_key
+        old_cls_name: str = server_cls.__name__
+        old_url: str = getattr(server_cls, "url", "") or ""
+        old_auth: str = getattr(server_cls, "auth_type", "headers") or "headers"
+
+        # Read current credential values from .env
+        env_path = project_path / ".env"
+        env_vars = _read_env_vars(env_path)
+        old_env_prefix = _to_env_key(old_server_name) + "_"
+
+        # Reconstruct current headers from .env
+        current_headers: dict[str, str] = {}
+        for hk in HEADER_KEYS:
+            env_key = _to_env_key(f"{old_server_name}_{hk}")
+            if env_key in env_vars:
+                current_headers[hk] = env_vars[env_key]
+
+        current_oauth_client_id = env_vars.get(
+            _to_env_key(f"{old_server_name}_OAUTH_CLIENT_ID"), ""
+        )
+        current_oauth_scopes = env_vars.get(
+            _to_env_key(f"{old_server_name}_OAUTH_SCOPES"), ""
+        )
+
+        # ── Step 1: Server details ────────────────────────────────────
+        print(f"\n=== Step 1: Edit Server Configuration (current name: {old_server_name}) ===\n")
+
+        server_name = _ask("Server name", old_server_name)
+        if not server_name:
+            print("A server name is required.")
+            return 1
+        server_description = _ask(
+            "Description", getattr(server_cls, "description", "") or ""
+        )
+        server_url = _ask("Server URL", old_url)
+        if not server_url:
+            print("A server URL is required.")
+            return 1
+
+        print("\nAuthentication type:")
+        for i, auth_option in enumerate(AUTH_TYPES, 1):
+            marker = "  ← current" if auth_option == old_auth else ""
+            print(f"  {i}. {auth_option}{marker}")
+        try:
+            old_auth_idx = AUTH_TYPES.index(old_auth) + 1
+        except ValueError:
+            old_auth_idx = 2
+        auth_choice = _ask("Select auth type", str(old_auth_idx))
+        try:
+            auth_idx = int(auth_choice) - 1
+            if auth_idx < 0 or auth_idx >= len(AUTH_TYPES):
+                raise ValueError
+        except ValueError:
+            auth_idx = old_auth_idx - 1
+        auth_type = AUTH_TYPES[auth_idx]
+        print(f"  → auth_type: {auth_type}\n")
+
+        headers: dict[str, str] = {}
+        oauth_client_id = ""
+        oauth_client_secret = ""
+        oauth_scopes = ""
+
+        if auth_type == "headers":
+            if current_headers:
+                print("Current headers:")
+                for k, v in current_headers.items():
+                    masked = v[:4] + "***" if len(v) > 4 else "***"
+                    print(f"  {k}: {masked}")
+                print()
+
+            print("Available header keys:")
+            for i, key in enumerate(HEADER_KEYS, 1):
+                current_marker = f"  ← {current_headers[key][:4]}***" if key in current_headers else ""
+                print(f"  {i}. {key}{current_marker}")
+            print("  0. Done adding headers")
+            print()
+
+            # Pre-fill current headers (user can replace or skip to keep them)
+            if current_headers and _ask_yes_no("Keep existing header values?", default=True):
+                headers = dict(current_headers)
+            else:
+                while True:
+                    hdr_choice = _ask("Select header key number (0 to finish)", "0")
+                    if hdr_choice == "0":
+                        break
+                    try:
+                        h_idx = int(hdr_choice) - 1
+                        if h_idx < 0 or h_idx >= len(HEADER_KEYS):
+                            raise ValueError
+                    except ValueError:
+                        print("Invalid selection, try again.")
+                        continue
+                    hk = HEADER_KEYS[h_idx]
+                    hv = _ask(f"  Value for '{hk}'", current_headers.get(hk, ""))
+                    if hv:
+                        headers[hk] = hv
+
+        elif auth_type == "oauth2":
+            print("OAuth 2.1 Configuration")
+            print("(Leave blank to keep current value)\n")
+            oauth_client_id = _ask("Client ID", current_oauth_client_id)
+            oauth_client_secret_raw = _ask_secret(
+                "Client Secret (leave blank to keep / skip)"
+                "\n  It is sent securely to the CogSol API (Azure Key Vault)."
+            )
+            oauth_client_secret = oauth_client_secret_raw
+            oauth_scopes = _ask("Scopes", current_oauth_scopes)
+
+        # ── Step 2: Tool discovery ────────────────────────────────────
+        print("\n=== Step 2: Discovering Tools ===\n")
+        print(f"Connecting to {server_url} ...")
+
+        discovery_headers = headers if auth_type == "headers" else {}
+        mcp_client = MCPClient(server_url, headers=discovery_headers, auth_type=auth_type)
+        connected = mcp_client.initialize()
+        tools = mcp_client.list_tools() if connected else []
+        mcp_client.disconnect()
+
+        if not tools and auth_type == "oauth2":
+            print("Direct connection failed — discovering tools via the Cognitive API...")
+            tools = self._discover_tools_via_api(
+                old_server_name=old_server_name,
+                old_server_url=old_url,
+                server_name=server_name,
+                server_url=server_url,
+                oauth_timeout=oauth_timeout,
+            )
+
+        keep_existing_tools = False
+        if not tools:
+            print("\nNo tools could be discovered (connection failed or none returned).")
+            if _ask_yes_no("Keep the existing tool definitions for this server?", default=True):
+                keep_existing_tools = True
+                print("  Existing tool classes will be kept (references updated if renamed).\n")
+            else:
+                print("  Existing tool classes will be REMOVED.\n")
+
+        selected_tools: list[dict[str, Any]] = []
+
+        if tools:
+            # Load current tools for this server to pre-mark as selected
+            all_tools: dict[str, Any] = classes.get("mcp_tools", {})
+            current_tool_names = {
+                getattr(tc, "name", tn)
+                for tn, tc in all_tools.items()
+                if (
+                    getattr(tc, "server", None) is server_cls
+                    or getattr(getattr(tc, "server", None), "__name__", None)
+                    == server_cls.__name__
+                )
+            }
+
+            print(f"\nFound {len(tools)} tool(s):\n")
+            for i, tool in enumerate(tools, 1):
+                current_mark = " [current]" if tool["name"] in current_tool_names else ""
+                desc = tool.get("description", "")
+                print(f"  {i}. {tool['name']}{current_mark}")
+                if desc:
+                    print(f"     {desc[:100]}")
+            print()
+
+            print("Enter tool numbers to keep (e.g. '1,3,5'), 'all' for all, or '0' to cancel:")
+            selection = _ask("Selection", "all")
+            if selection == "0":
+                print("Cancelled.")
+                return 0
+            if selection.lower() == "all":
+                selected_tools = tools
+            else:
+                idxs: list[int] = []
+                for part in selection.split(","):
+                    part = part.strip()
+                    if part.isdigit():
+                        ti = int(part) - 1
+                        if 0 <= ti < len(tools):
+                            idxs.append(ti)
+                selected_tools = [tools[i] for i in idxs]
+
+        # ── Step 3: Update source files ───────────────────────────────
+        print("=== Step 3: Updating Files ===\n")
+
+        # Derive new class name from (possibly new) server name.
+        cls_base = re.sub(r"[^a-zA-Z0-9]+", " ", server_name).title().replace(" ", "")
+        new_cls_name = f"{cls_base}MCPServer"
+        new_env_prefix = _to_env_key(server_name) + "_"
+
+        # Build env vars for new credentials.
+        env_new_vars: dict[str, str] = {}
+
+        if auth_type == "none":
+            server_body_lines = [
+                f"    name = {_py_str(server_name)}",
+                f"    description = {_py_str(server_description)}",
+                '    auth_type = "none"',
+                f"    url = {_py_str(server_url)}",
+            ]
+        elif auth_type == "headers":
+            header_attr_lines: list[str] = []
+            for hk, hv in headers.items():
+                env_key = _to_env_key(f"{server_name}_{hk}")
+                env_new_vars[env_key] = hv
+                header_attr_lines.append(
+                    f"        {_py_str(hk)}: os.environ.get({_py_str(env_key)}, ''),"
+                )
+            headers_block = (
+                "{\n" + "\n".join(header_attr_lines) + "\n    }" if header_attr_lines else "{}"
+            )
+            server_body_lines = [
+                f"    name = {_py_str(server_name)}",
+                f"    description = {_py_str(server_description)}",
+                f"    url = {_py_str(server_url)}",
+                f"    headers = {headers_block}",
+            ]
+        else:  # oauth2
+            oauth_cid_env = _to_env_key(f"{server_name}_OAUTH_CLIENT_ID")
+            oauth_scopes_env = _to_env_key(f"{server_name}_OAUTH_SCOPES")
+            if oauth_client_id:
+                env_new_vars[oauth_cid_env] = oauth_client_id
+            if oauth_scopes:
+                env_new_vars[oauth_scopes_env] = oauth_scopes
+            server_body_lines = [
+                f"    name = {_py_str(server_name)}",
+                f"    description = {_py_str(server_description)}",
+                '    auth_type = "oauth2"',
+                f"    url = {_py_str(server_url)}",
+            ]
+            if oauth_client_id:
+                server_body_lines.append(
+                    f"    oauth_client_id = os.environ.get({_py_str(oauth_cid_env)}, '')"
+                )
+            if oauth_scopes:
+                server_body_lines.append(
+                    f"    oauth_scopes = os.environ.get({_py_str(oauth_scopes_env)}, '')"
+                )
+
+        header_imports = (["import os", ""] if auth_type != "none" else []) + [
+            "from cogsol.tools import BaseMCPServer",
+            "",
+            "",
+        ]
+        server_code = "\n".join(
+            header_imports
+            + [
+                f"class {new_cls_name}(BaseMCPServer):",
+                '    """MCP server definition."""',
+                "",
+                "\n".join(server_body_lines),
+                "",
+            ]
+        )
+
+        # Build tool classes.
+        tool_classes: list[str] = []
+        for tool in selected_tools:
+            t_name = tool["name"]
+            t_desc = tool.get("description", "") or ""
+            t_cls_base = re.sub(r"[^a-zA-Z0-9]+", " ", t_name).title().replace(" ", "")
+            t_cls_name = f"{t_cls_base}MCPTool"
+            tool_classes.append(
+                "\n".join(
+                    [
+                        "",
+                        "",
+                        f"class {t_cls_name}(BaseMCPTool):",
+                        '    """MCP tool definition."""',
+                        "",
+                        f"    name = {_py_str(t_name)}",
+                        f"    description = {_py_str(t_desc)}",
+                        f"    server = {new_cls_name}",
+                        "",
+                    ]
+                )
+            )
+
+        tools_header = "\n".join(
+            [
+                "from cogsol.tools import BaseMCPTool",
+                "",
+                f"from {app}.mcp_servers import {new_cls_name}",
+            ]
+        )
+        tools_code = tools_header + "".join(tool_classes)
+
+        app_path = project_path / app
+        servers_file = app_path / "mcp_servers.py"
+        tools_file = app_path / "mcp_tools.py"
+
+        # -- Remove old server class --
+        if servers_file.exists():
+            source = servers_file.read_text(encoding="utf-8")
+            new_source, removed = _remove_class_from_source(source, old_cls_name)
+            if removed:
+                # Append new class (strip duplicate imports — they likely already exist)
+                existing = new_source.rstrip()
+                class_only = (
+                    "\n\n"
+                    + "\n".join(
+                        ln
+                        for ln in server_code.splitlines()
+                        if not ln.startswith("import ") and not ln.startswith("from ")
+                    ).strip()
+                    + "\n"
+                )
+                servers_file.write_text(existing + class_only, encoding="utf-8")
+                print(f"  Updated {old_cls_name} → {new_cls_name} in mcp_servers.py")
+            else:
+                # Class not found — append as new.
+                servers_file.write_text(
+                    servers_file.read_text(encoding="utf-8").rstrip()
+                    + "\n\n"
+                    + "\n".join(
+                        ln
+                        for ln in server_code.splitlines()
+                        if not ln.startswith("import ") and not ln.startswith("from ")
+                    ).strip()
+                    + "\n",
+                    encoding="utf-8",
+                )
+                print(f"  Appended {new_cls_name} to mcp_servers.py (old class not found)")
+        else:
+            servers_file.write_text(server_code, encoding="utf-8")
+            print(f"  Created mcp_servers.py with {new_cls_name}")
+
+        # -- Remove old tool classes that referenced the old server --
+        old_import_line = f"from {app}.mcp_servers import {old_cls_name}"
+        new_import_line = f"from {app}.mcp_servers import {new_cls_name}"
+
+        if tools_file.exists():
+            source = tools_file.read_text(encoding="utf-8")
+            if not keep_existing_tools:
+                # Remove tool classes belonging to the old server.
+                all_tools_classes: dict[str, Any] = classes.get("mcp_tools", {})
+                for tn, tc in all_tools_classes.items():
+                    if (
+                        getattr(tc, "server", None) is server_cls
+                        or getattr(getattr(tc, "server", None), "__name__", None)
+                        == old_cls_name
+                    ):
+                        source, _ = _remove_class_from_source(source, tc.__name__)
+
+            # Update import line and server references in kept tool classes.
+            source = source.replace(old_import_line, new_import_line)
+            source = source.replace(f"server = {old_cls_name}", f"server = {new_cls_name}")
+
+            # Ensure new import line exists.
+            if new_import_line not in source:
+                source = source.rstrip() + f"\n{new_import_line}\n"
+
+            # Append new tool classes.
+            for cls_block in tool_classes:
+                cls_name_match = re.search(r"class (\w+)\(", cls_block)
+                if cls_name_match and cls_name_match.group(1) not in source:
+                    source = source.rstrip() + cls_block
+
+            tools_file.write_text(source, encoding="utf-8")
+            print(f"  Updated mcp_tools.py")
+        elif tool_classes:
+            tools_file.write_text(tools_code, encoding="utf-8")
+            print(f"  Created mcp_tools.py")
+
+        # -- Update .env --
+        # If the server name changed, remove all old prefix vars and write new ones.
+        name_changed = old_server_name.strip().casefold() != server_name.strip().casefold()
+        old_env_keys_for_server: set[str] = set()
+        if name_changed:
+            for k in env_vars:
+                if k.startswith(old_env_prefix):
+                    old_env_keys_for_server.add(k)
+
+        _update_env_file(
+            env_path,
+            remove_keys=old_env_keys_for_server,
+            update=env_new_vars,
+            section_comment=server_name if env_new_vars else "",
+        )
+        if env_new_vars or old_env_keys_for_server:
+            changes = len(env_new_vars) + len(old_env_keys_for_server)
+            print(f"  Updated .env ({changes} change(s)).")
+        else:
+            print("  .env already up-to-date.")
+
+        # -- Publish to Cognitive --
+        print(
+            "\nPublishing updated MCP server/tools to Cognitive..."
+        )
+        try:
+            self._publish_update(
+                server_name=server_name,
+                server_description=server_description,
+                server_url=server_url,
+                auth_type=auth_type,
+                headers=headers,
+                oauth_client_id=oauth_client_id,
+                oauth_client_secret=oauth_client_secret,
+                oauth_scopes=oauth_scopes,
+                selected_tools=selected_tools,
+                old_server_name=old_server_name,
+                old_server_url=old_url,
+                oauth_timeout=oauth_timeout,
+            )
+        except CogSolAPIError as exc:
+            print(f"Failed to publish to Cognitive: {exc}")
+            return 1
+
+        # -- Update .state.json --
+        state_path = project_path / app / "migrations" / ".state.json"
+        if state_path.exists():
+            try:
+                state: dict[str, Any] = json.loads(state_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                state = {}
+
+            local_state = state.get("state", {})
+            # Move state entry if name changed.
+            if name_changed:
+                mcp_srv_state = local_state.get("mcp_servers", {})
+                entry = mcp_srv_state.pop(old_server_key, None)
+                if entry:
+                    mcp_srv_state[server_name] = entry
+
+            state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            print("  Updated .state.json")
+
+        print(
+            "\nDone! Run 'python manage.py makemigrations' followed by "
+            "'python manage.py migrate'."
+        )
+        return 0

--- a/cogsol/management/commands/editmcptools.py
+++ b/cogsol/management/commands/editmcptools.py
@@ -197,9 +197,7 @@ def _start_oauth_authorization(
     auth_payload = client.get_mcp_oauth_authorization_url(server_id) or {}
     url = auth_payload.get("authorization_url")
     if not url:
-        raise CogSolAPIError(
-            f"OAuth authorization URL could not be generated for '{server_name}'."
-        )
+        raise CogSolAPIError(f"OAuth authorization URL could not be generated for '{server_name}'.")
     if not webbrowser.open(str(url), new=1, autoraise=True):
         print(f"  Open this URL manually: {url}")
     if not _wait_for_oauth_connected(
@@ -237,6 +235,7 @@ class Command(BaseCommand):
     ) -> dict[str, Any] | None:
         def norm(s: Any) -> str:
             return re.sub(r"\s+", " ", str(s or "")).strip().casefold()
+
         try:
             payload = client.list_mcp_servers()
             results = payload if isinstance(payload, list) else (payload or {}).get("results", [])
@@ -301,9 +300,7 @@ class Command(BaseCommand):
 
         remote = self._find_remote_server(
             client=client, server_name=old_server_name, server_url=old_server_url
-        ) or self._find_remote_server(
-            client=client, server_name=server_name, server_url=server_url
-        )
+        ) or self._find_remote_server(client=client, server_name=server_name, server_url=server_url)
         if not remote or not remote.get("id"):
             print("  Server not found in Cognitive; cannot discover tools via API.")
             return []
@@ -511,9 +508,7 @@ class Command(BaseCommand):
         current_oauth_client_id = env_vars.get(
             _to_env_key(f"{old_server_name}_OAUTH_CLIENT_ID"), ""
         )
-        current_oauth_scopes = env_vars.get(
-            _to_env_key(f"{old_server_name}_OAUTH_SCOPES"), ""
-        )
+        current_oauth_scopes = env_vars.get(_to_env_key(f"{old_server_name}_OAUTH_SCOPES"), "")
 
         # ── Step 1: Server details ────────────────────────────────────
         print(f"\n=== Step 1: Edit Server Configuration (current name: {old_server_name}) ===\n")
@@ -522,9 +517,7 @@ class Command(BaseCommand):
         if not server_name:
             print("A server name is required.")
             return 1
-        server_description = _ask(
-            "Description", getattr(server_cls, "description", "") or ""
-        )
+        server_description = _ask("Description", getattr(server_cls, "description", "") or "")
         server_url = _ask("Server URL", old_url)
         if not server_url:
             print("A server URL is required.")
@@ -563,7 +556,9 @@ class Command(BaseCommand):
 
             print("Available header keys:")
             for i, key in enumerate(HEADER_KEYS, 1):
-                current_marker = f"  ← {current_headers[key][:4]}***" if key in current_headers else ""
+                current_marker = (
+                    f"  ← {current_headers[key][:4]}***" if key in current_headers else ""
+                )
                 print(f"  {i}. {key}{current_marker}")
             print("  0. Done adding headers")
             print()
@@ -638,8 +633,7 @@ class Command(BaseCommand):
                 for tn, tc in all_tools.items()
                 if (
                     getattr(tc, "server", None) is server_cls
-                    or getattr(getattr(tc, "server", None), "__name__", None)
-                    == server_cls.__name__
+                    or getattr(getattr(tc, "server", None), "__name__", None) == server_cls.__name__
                 )
             }
 
@@ -825,8 +819,7 @@ class Command(BaseCommand):
                 for tc in all_tools_classes.values():
                     if (
                         getattr(tc, "server", None) is server_cls
-                        or getattr(getattr(tc, "server", None), "__name__", None)
-                        == old_cls_name
+                        or getattr(getattr(tc, "server", None), "__name__", None) == old_cls_name
                     ):
                         source, _ = _remove_class_from_source(source, tc.__name__)
 
@@ -872,9 +865,7 @@ class Command(BaseCommand):
             print("  .env already up-to-date.")
 
         # -- Publish to Cognitive --
-        print(
-            "\nPublishing updated MCP server/tools to Cognitive..."
-        )
+        print("\nPublishing updated MCP server/tools to Cognitive...")
         try:
             self._publish_update(
                 server_name=server_name,

--- a/cogsol/management/commands/editmcptools.py
+++ b/cogsol/management/commands/editmcptools.py
@@ -28,7 +28,6 @@ import os
 import re
 import time
 import webbrowser
-from getpass import getpass
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +48,6 @@ from cogsol.management.commands.addmcptools import (
     _py_str,
     _to_env_key,
 )
-
 
 # ---------------------------------------------------------------------------
 # File-manipulation helpers
@@ -237,7 +235,8 @@ class Command(BaseCommand):
         server_name: str,
         server_url: str,
     ) -> dict[str, Any] | None:
-        norm = lambda s: re.sub(r"\s+", " ", str(s or "")).strip().casefold()
+        def norm(s: Any) -> str:
+            return re.sub(r"\s+", " ", str(s or "")).strip().casefold()
         try:
             payload = client.list_mcp_servers()
             results = payload if isinstance(payload, list) else (payload or {}).get("results", [])
@@ -676,7 +675,6 @@ class Command(BaseCommand):
         # Derive new class name from (possibly new) server name.
         cls_base = re.sub(r"[^a-zA-Z0-9]+", " ", server_name).title().replace(" ", "")
         new_cls_name = f"{cls_base}MCPServer"
-        new_env_prefix = _to_env_key(server_name) + "_"
 
         # Build env vars for new credentials.
         env_new_vars: dict[str, str] = {}
@@ -824,7 +822,7 @@ class Command(BaseCommand):
             if not keep_existing_tools:
                 # Remove tool classes belonging to the old server.
                 all_tools_classes: dict[str, Any] = classes.get("mcp_tools", {})
-                for tn, tc in all_tools_classes.items():
+                for tc in all_tools_classes.values():
                     if (
                         getattr(tc, "server", None) is server_cls
                         or getattr(getattr(tc, "server", None), "__name__", None)
@@ -847,10 +845,10 @@ class Command(BaseCommand):
                     source = source.rstrip() + cls_block
 
             tools_file.write_text(source, encoding="utf-8")
-            print(f"  Updated mcp_tools.py")
+            print("  Updated mcp_tools.py")
         elif tool_classes:
             tools_file.write_text(tools_code, encoding="utf-8")
-            print(f"  Created mcp_tools.py")
+            print("  Created mcp_tools.py")
 
         # -- Update .env --
         # If the server name changed, remove all old prefix vars and write new ones.

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -612,7 +612,10 @@ class {class_name}(BaseAgent):
                                 server_ref_int = int(server_ref) if server_ref is not None else None
                             except (TypeError, ValueError):
                                 server_ref_int = None
-                            if server_ref_int is not None and server_ref_int not in mcp_servers_cache:
+                            if (
+                                server_ref_int is not None
+                                and server_ref_int not in mcp_servers_cache
+                            ):
                                 try:
                                     mcp_servers_cache[server_ref_int] = client.get_mcp_server(
                                         server_ref_int
@@ -736,17 +739,14 @@ class {class_name}(BaseAgent):
                 for mt in s_tools:
                     tool_cls_name = _mcp_tool_class_name_from_data(mt)
                     if not _has_class_def(existing_tools, tool_cls_name):
-                        tool_block = "\n\n" + _mcp_tool_class_from_api(mt, srv_cls_name).strip() + "\n"
-                        existing_tools = existing_tools.rstrip() + tool_block
-                        import_messages.append(
-                            f"MCP tool: {tool_cls_name} -> {mcp_tools_file}"
+                        tool_block = (
+                            "\n\n" + _mcp_tool_class_from_api(mt, srv_cls_name).strip() + "\n"
                         )
+                        existing_tools = existing_tools.rstrip() + tool_block
+                        import_messages.append(f"MCP tool: {tool_cls_name} -> {mcp_tools_file}")
                 _write_file(mcp_tools_file, existing_tools)
             else:
-                header = (
-                    "from cogsol.tools import BaseMCPTool\n\n"
-                    f"{import_line}\n"
-                )
+                header = "from cogsol.tools import BaseMCPTool\n\n" f"{import_line}\n"
                 blocks = "\n\n".join(
                     _mcp_tool_class_from_api(mt, srv_cls_name).strip() for mt in s_tools
                 )
@@ -769,7 +769,9 @@ class {class_name}(BaseAgent):
                 for ln in env_lines
                 if "=" in ln and not ln.strip().startswith("#")
             }
-            new_vars = {k: v for k, v in env_placeholders_needed.items() if k not in existing_env_keys}
+            new_vars = {
+                k: v for k, v in env_placeholders_needed.items() if k not in existing_env_keys
+            }
             if new_vars:
                 env_lines.append("")
                 env_lines.append("# MCP credentials (imported - fill in values)")

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -173,6 +173,34 @@ def _retrieval_tool_class_name(tool: dict[str, Any]) -> str:
     return base_name if base_name.endswith("Search") else base_name + "Search"
 
 
+def _search_filter_names(tool: dict[str, Any]) -> list[str]:
+    """Collapse the Cognitive ``filters`` list into unique metadata names.
+
+    Date filters are stored as three entries (name, name_start, name_end) —
+    group them by metadata_config_id (or stripped base name) and keep one.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for f in tool.get("filters") or []:
+        if not isinstance(f, dict):
+            continue
+        fname = str(f.get("name") or "").strip()
+        if not fname:
+            continue
+        base = fname
+        for suffix in ("_start", "_end"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        cfg_id = f.get("metadata_config_id")
+        key = f"id:{cfg_id}" if cfg_id is not None else f"name:{base}"
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(base)
+    return names
+
+
 def _retrieval_tool_class_from_api(tool: dict[str, Any], retrieval_name: str | None) -> str:
     name = tool.get("name") or "Search"
     class_name = _retrieval_tool_class_name(tool)
@@ -188,6 +216,8 @@ def _retrieval_tool_class_from_api(tool: dict[str, Any], retrieval_name: str | N
             }
         )
     retrieval_value = retrieval_name if retrieval_name is not None else None
+    filter_names = _search_filter_names(tool)
+    filters_line = f"\n    filters = {filter_names!r}" if filter_names else ""
 
     template = f"""
 class {class_name}(BaseRetrievalTool):
@@ -196,7 +226,7 @@ class {class_name}(BaseRetrievalTool):
     name = {name!r}
     description = {description!r}
     retrieval = {retrieval_value!r}
-    parameters = {params!r}
+    parameters = {params!r}{filters_line}
     show_tool_message = {bool(tool.get("show_tool_message", False))}
     show_assistant_message = {bool(tool.get("show_assistant_message", False))}
     edit_available = {bool(tool.get("edit_available", True))}
@@ -274,6 +304,124 @@ def _lesson_class(item: dict[str, Any]) -> str:
     )
 
 
+def _has_class_def(source: str, class_name: str) -> bool:
+    """True if *source* contains a real (non-commented) top-level class definition.
+
+    A plain substring check would also match commented-out template examples
+    (e.g. ``# class AtlassianMCPServer(BaseMCPServer):``).
+    """
+    return re.search(rf"^class\s+{re.escape(class_name)}\b", source, re.MULTILINE) is not None
+
+
+def _mcp_server_class_name(server: dict[str, Any]) -> str:
+    name = server.get("name") or "MCPServer"
+    base = _safe_class_name(name, "MCPServer")
+    return base if base.endswith("MCPServer") else base + "MCPServer"
+
+
+def _mcp_tool_class_name_from_data(tool: dict[str, Any]) -> str:
+    name = tool.get("name") or "MCPTool"
+    base = _safe_class_name(name, "MCPTool")
+    return base if base.endswith("MCPTool") else base + "MCPTool"
+
+
+def _mcp_env_key(server_name: str, suffix: str) -> str:
+    base = re.sub(r"[^a-zA-Z0-9]+", "_", server_name).strip("_").upper()
+    suf = re.sub(r"[^a-zA-Z0-9]+", "_", suffix).strip("_").upper()
+    return f"MCP_{base}_{suf}"
+
+
+def _mcp_server_class_from_api(server: dict[str, Any]) -> str:
+    """Generate a BaseMCPServer subclass from API data.
+
+    Header values are stored in Key Vault and not returned by the API,
+    so the generated class references env vars that the user must fill in.
+    """
+    name = server.get("name") or "MCPServer"
+    cls_name = _mcp_server_class_name(server)
+    description = server.get("description") or ""
+    url = server.get("url") or ""
+    auth_type = server.get("auth_type") or "none"
+
+    if auth_type == "headers":
+        header_keys = list((server.get("headers") or {}).keys())
+        header_attr_lines: list[str] = []
+        for hk in header_keys:
+            env_key = _mcp_env_key(name, hk)
+            header_attr_lines.append(f"        {hk!r}: os.environ.get({env_key!r}, ''),")
+        headers_block = (
+            "{\n" + "\n".join(header_attr_lines) + "\n    }" if header_attr_lines else "{}"
+        )
+        body = (
+            f"    name = {name!r}\n"
+            f"    description = {description!r}\n"
+            f"    url = {url!r}\n"
+            f"    headers = {headers_block}"
+        )
+        imports_prefix = "import os\n\nfrom cogsol.tools import BaseMCPServer\n\n\n"
+    elif auth_type == "oauth2":
+        oauth_config = server.get("oauth_config") or {}
+        client_id = oauth_config.get("client_id") or ""
+        scopes = oauth_config.get("scopes") or ""
+        cid_env = _mcp_env_key(name, "OAUTH_CLIENT_ID")
+        scopes_env = _mcp_env_key(name, "OAUTH_SCOPES")
+        body_lines = [
+            f"    name = {name!r}",
+            f"    description = {description!r}",
+            '    auth_type = "oauth2"',
+            f"    url = {url!r}",
+        ]
+        if client_id:
+            body_lines.append(f"    oauth_client_id = os.environ.get({cid_env!r}, '')")
+        if scopes:
+            body_lines.append(f"    oauth_scopes = os.environ.get({scopes_env!r}, '')")
+        body = "\n".join(body_lines)
+        imports_prefix = "import os\n\nfrom cogsol.tools import BaseMCPServer\n\n\n"
+    else:
+        body = (
+            f"    name = {name!r}\n"
+            f"    description = {description!r}\n"
+            '    auth_type = "none"\n'
+            f"    url = {url!r}"
+        )
+        imports_prefix = "from cogsol.tools import BaseMCPServer\n\n\n"
+
+    return (
+        f"{imports_prefix}class {cls_name}(BaseMCPServer):\n"
+        f'    """MCP server definition (imported from CogSol API)."""\n\n'
+        f"{body}\n"
+    )
+
+
+def _mcp_tool_class_from_api(tool: dict[str, Any], server_cls_name: str) -> str:
+    name = tool.get("name") or "tool"
+    cls_name = _mcp_tool_class_name_from_data(tool)
+    description = tool.get("description") or ""
+    return (
+        f"class {cls_name}(BaseMCPTool):\n"
+        f'    """MCP tool definition (imported from CogSol API)."""\n\n'
+        f"    name = {name!r}\n"
+        f"    description = {description!r}\n"
+        f"    server = {server_cls_name}\n"
+    )
+
+
+def _mcp_server_env_placeholders(server: dict[str, Any]) -> dict[str, str]:
+    """Return env vars that need to be set for this server (with empty placeholder values)."""
+    name = server.get("name") or "MCPServer"
+    auth_type = server.get("auth_type") or "none"
+    placeholders: dict[str, str] = {}
+    if auth_type == "headers":
+        for hk in (server.get("headers") or {}).keys():
+            placeholders[_mcp_env_key(name, hk)] = ""
+    elif auth_type == "oauth2":
+        oauth_config = server.get("oauth_config") or {}
+        if oauth_config.get("client_id"):
+            placeholders[_mcp_env_key(name, "OAUTH_CLIENT_ID")] = oauth_config["client_id"]
+        placeholders[_mcp_env_key(name, "OAUTH_SCOPES")] = oauth_config.get("scopes") or ""
+    return placeholders
+
+
 class Command(BaseCommand):
     help = "Import an existing CogSol assistant into the local project."
 
@@ -344,6 +492,34 @@ class Command(BaseCommand):
         gen_pre_expr = "genconfigs.QA()" if str(gen_pre).upper() == "QA" else repr(gen_pre)
 
         has_retrieval_tools = False
+
+        # Personalization: the portal stores camelCase color keys; older
+        # framework-migrated assistants may have snake_case leftovers.
+        assistant_colors = assistant.get("colors") or {}
+        if not isinstance(assistant_colors, dict):
+            assistant_colors = {}
+
+        def _color(camel: str, snake: str) -> Any:
+            return assistant_colors.get(camel) or assistant_colors.get(snake) or None
+
+        meta_lines = [
+            f"        name = {class_name!r}",
+            f"        chat_name = {agent_desc!r}",
+        ]
+        if assistant.get("info"):
+            meta_lines.append(f"        alias = {assistant.get('info')!r}")
+        meta_lines.append(f"        logo_url = {assistant.get('logo')!r}")
+        personalization = {
+            "assistant_name_color": _color("nameColor", "assistant_name_color"),
+            "primary_color": _color("primaryColor", "primary_color"),
+            "secondary_color": _color("secondaryColor", "secondary_color"),
+            "border_color": _color("borderColor", "border_color"),
+        }
+        for meta_attr, color_value in personalization.items():
+            if color_value:
+                meta_lines.append(f"        {meta_attr} = {color_value!r}")
+        meta_block = "\n".join(meta_lines)
+
         agent_py = f"""from cogsol.agents import BaseAgent, genconfigs
 from cogsol.prompts import Prompts
 from ..tools import *
@@ -364,9 +540,7 @@ class {class_name}(BaseAgent):
     no_information_message = {assistant.get("not_info_message")!r}
 
     class Meta:
-        name = {class_name!r}
-        chat_name = {agent_desc!r}
-        logo_url = {assistant.get("logo")!r}
+{meta_block}
 """
         _write_file(agent_dir / "agent.py", agent_py)
         _write_file(agent_dir / "__init__.py", f"from .agent import {class_name}\n")
@@ -380,6 +554,9 @@ class {class_name}(BaseAgent):
         retrieval_tools: list[dict[str, Any]] = []
         retrieval_tools_by_id: dict[int, dict[str, Any]] = {}
         retrieval_cache: dict[int, str | None] = {}
+        mcp_tools: list[dict[str, Any]] = []
+        mcp_tools_by_id: dict[int, dict[str, Any]] = {}
+        mcp_servers_cache: dict[int, dict[str, Any]] = {}
 
         def _resolve_retrieval_name(retrieval_id: int | None) -> str | None:
             if not retrieval_id:
@@ -410,8 +587,29 @@ class {class_name}(BaseAgent):
                     retrieval_tool["_retrieval_name"] = retrieval_name
                     retrieval_tools.append(retrieval_tool)
                     retrieval_tools_by_id[int(tool_id)] = retrieval_tool
-                except CogSolAPIError as exc2:
-                    print(f"Warning: could not import tool {tool_id}: {exc2}")
+                except CogSolAPIError:
+                    try:
+                        mcp_tool = client.get_mcp_tool(tool_id)
+                        if isinstance(mcp_tool, dict):
+                            server_ref = mcp_tool.get("server") or mcp_tool.get("server_id")
+                            # server may be a nested dict {"id": N, ...} instead of a bare int
+                            if isinstance(server_ref, dict):
+                                server_ref = server_ref.get("id")
+                            try:
+                                server_ref_int = int(server_ref) if server_ref is not None else None
+                            except (TypeError, ValueError):
+                                server_ref_int = None
+                            if server_ref_int is not None and server_ref_int not in mcp_servers_cache:
+                                try:
+                                    mcp_servers_cache[server_ref_int] = client.get_mcp_server(
+                                        server_ref_int
+                                    )
+                                except CogSolAPIError:
+                                    mcp_servers_cache[server_ref_int] = {}
+                            mcp_tools.append(mcp_tool)
+                            mcp_tools_by_id[int(tool_id)] = mcp_tool
+                    except CogSolAPIError as exc3:
+                        print(f"  Warning: could not import tool {tool_id}: {exc3}")
 
         tools_file = project_path / app / "tools.py"
         existing = tools_file.read_text(encoding="utf-8") if tools_file.exists() else ""
@@ -457,6 +655,121 @@ class {class_name}(BaseAgent):
         if retrieval_tools:
             has_retrieval_tools = True
 
+        # -- MCP servers and tools --
+        has_mcp_tools = False
+        mcp_servers_file = project_path / app / "mcp_servers.py"
+        mcp_tools_file = project_path / app / "mcp_tools.py"
+
+        # Group MCP tools by their server id.
+        # server may be a bare int, a string, or a nested dict {"id": N, ...}.
+        mcp_server_tool_map: dict[int, list[dict[str, Any]]] = {}
+        for mt in mcp_tools:
+            server_ref = mt.get("server") or mt.get("server_id")
+            if isinstance(server_ref, dict):
+                server_ref = server_ref.get("id")
+            try:
+                server_ref_int = int(server_ref) if server_ref is not None else None
+            except (TypeError, ValueError):
+                server_ref_int = None
+            if server_ref_int is not None:
+                mcp_server_tool_map.setdefault(server_ref_int, []).append(mt)
+
+        env_path = project_path / ".env"
+        env_placeholders_needed: dict[str, str] = {}
+
+        for server_id, s_tools in mcp_server_tool_map.items():
+            server_data = mcp_servers_cache.get(server_id) or {}
+            # If the server fetch failed, build a minimal stub from what we know.
+            if not server_data:
+                first_tool = s_tools[0] if s_tools else {}
+                inferred_name = (
+                    first_tool.get("server_name")
+                    or first_tool.get("mcp_server_name")
+                    or f"MCPServer{server_id}"
+                )
+                server_data = {"id": server_id, "name": inferred_name}
+                print(
+                    f"  Warning: could not fetch MCP server {server_id} from API; "
+                    f"generating stub class '{inferred_name}'."
+                )
+            srv_cls_name = _mcp_server_class_name(server_data)
+
+            # Write/append server class.
+            server_code = _mcp_server_class_from_api(server_data)
+            if mcp_servers_file.exists():
+                existing_srv = mcp_servers_file.read_text(encoding="utf-8")
+                if not _has_class_def(existing_srv, srv_cls_name):
+                    class_only = (
+                        "\n\n"
+                        + "\n".join(
+                            ln
+                            for ln in server_code.splitlines()
+                            if not ln.startswith("import ") and not ln.startswith("from ")
+                        ).strip()
+                        + "\n"
+                    )
+                    _write_file(mcp_servers_file, existing_srv.rstrip() + class_only)
+                    import_messages.append(f"MCP server: {srv_cls_name} -> {mcp_servers_file}")
+            else:
+                _write_file(mcp_servers_file, server_code)
+                import_messages.append(f"MCP server: {srv_cls_name} -> {mcp_servers_file}")
+
+            # Write/append tool classes.
+            import_line = f"from {app}.mcp_servers import {srv_cls_name}"
+            if mcp_tools_file.exists():
+                existing_tools = mcp_tools_file.read_text(encoding="utf-8")
+                if import_line not in existing_tools:
+                    existing_tools = existing_tools.rstrip() + f"\n{import_line}\n"
+                for mt in s_tools:
+                    tool_cls_name = _mcp_tool_class_name_from_data(mt)
+                    if not _has_class_def(existing_tools, tool_cls_name):
+                        tool_block = "\n\n" + _mcp_tool_class_from_api(mt, srv_cls_name).strip() + "\n"
+                        existing_tools = existing_tools.rstrip() + tool_block
+                        import_messages.append(
+                            f"MCP tool: {tool_cls_name} -> {mcp_tools_file}"
+                        )
+                _write_file(mcp_tools_file, existing_tools)
+            else:
+                header = (
+                    "from cogsol.tools import BaseMCPTool\n\n"
+                    f"{import_line}\n"
+                )
+                blocks = "\n\n".join(
+                    _mcp_tool_class_from_api(mt, srv_cls_name).strip() for mt in s_tools
+                )
+                _write_file(mcp_tools_file, header + "\n\n" + blocks + "\n")
+                for mt in s_tools:
+                    import_messages.append(
+                        f"MCP tool: {_mcp_tool_class_name_from_data(mt)} -> {mcp_tools_file}"
+                    )
+
+            # Collect env-var placeholders.
+            env_placeholders_needed.update(_mcp_server_env_placeholders(server_data))
+
+        # Write placeholder env vars (empty values to signal what must be configured).
+        if env_placeholders_needed:
+            env_lines: list[str] = []
+            if env_path.exists():
+                env_lines = env_path.read_text(encoding="utf-8").splitlines()
+            existing_env_keys = {
+                ln.split("=", 1)[0].strip()
+                for ln in env_lines
+                if "=" in ln and not ln.strip().startswith("#")
+            }
+            new_vars = {k: v for k, v in env_placeholders_needed.items() if k not in existing_env_keys}
+            if new_vars:
+                env_lines.append("")
+                env_lines.append("# MCP credentials (imported - fill in values)")
+                env_lines.extend(f"{k}={v}" for k, v in new_vars.items())
+                _write_file(env_path, "\n".join(env_lines) + "\n")
+                print(
+                    f"  Added {len(new_vars)} MCP credential placeholder(s) to .env — "
+                    "fill in the values before running migrate."
+                )
+
+        if mcp_tools:
+            has_mcp_tools = True
+
         # Update tools list in agent.py
         def class_name_for_script(script_id: int) -> str | None:
             script = scripts_by_id.get(int(script_id))
@@ -471,8 +784,18 @@ class {class_name}(BaseAgent):
                 return None
             return _retrieval_tool_class_name(tool)
 
+        def class_name_for_mcp_tool(tool_id: int) -> str | None:
+            mt = mcp_tools_by_id.get(int(tool_id))
+            if not mt:
+                return None
+            return _mcp_tool_class_name_from_data(mt)
+
         def _tool_class_for_id(tool_id: int) -> str | None:
-            return class_name_for_script(tool_id) or class_name_for_retrieval_tool(tool_id)
+            return (
+                class_name_for_script(tool_id)
+                or class_name_for_retrieval_tool(tool_id)
+                or class_name_for_mcp_tool(tool_id)
+            )
 
         tool_class_names = [n for n in (_tool_class_for_id(sid) for sid in tools_ids) if n]
         pretool_class_names = [n for n in (_tool_class_for_id(sid) for sid in pretools_ids) if n]
@@ -482,6 +805,11 @@ class {class_name}(BaseAgent):
             agent_source = agent_source.replace(
                 "from ..tools import *",
                 "from ..tools import *\nfrom ..searches import *",
+            )
+        if has_mcp_tools and "from ..mcp_tools import *" not in agent_source:
+            agent_source = agent_source.replace(
+                "from ..tools import *",
+                "from ..tools import *\nfrom ..mcp_tools import *",
             )
         agent_source = agent_source.replace(
             "    tools = []", f"    tools = [{', '.join(n + '()' for n in tool_class_names)}]"
@@ -531,6 +859,7 @@ class {class_name}(BaseAgent):
                 "name": tname,
                 "description": tool.get("description"),
                 "parameters": tool.get("parameters") or [],
+                "filters": _search_filter_names(tool),
                 "retrieval": tool.get("_retrieval_name") or None,
                 "show_tool_message": bool(tool.get("show_tool_message", False)),
                 "show_assistant_message": bool(tool.get("show_assistant_message", False)),
@@ -548,6 +877,9 @@ class {class_name}(BaseAgent):
             rtool = retrieval_tools_by_id.get(int(tool_id))
             if rtool:
                 return rtool.get("name")
+            mt = mcp_tools_by_id.get(int(tool_id))
+            if mt:
+                return mt.get("name")
             return None
 
         agent_fields = {
@@ -599,10 +931,44 @@ class {class_name}(BaseAgent):
             "chat_name": agent_desc,
             "logo_url": assistant.get("logo"),
         }
+        if assistant.get("info"):
+            meta["alias"] = assistant.get("info")
+        for meta_attr, color_value in personalization.items():
+            if color_value:
+                meta[meta_attr] = color_value
+
+        mcp_server_ops: list[str] = []
+        mcp_tool_ops: list[str] = []
+        for server_id, s_tools in mcp_server_tool_map.items():
+            server_data = mcp_servers_cache.get(server_id) or {}
+            if not server_data:
+                continue
+            sname = server_data.get("name") or f"mcp_server_{server_id}"
+            srv_fields = {
+                "name": sname,
+                "description": server_data.get("description") or "",
+                "url": server_data.get("url") or "",
+                "auth_type": server_data.get("auth_type") or "none",
+            }
+            mcp_server_ops.append(
+                f"        migrations.CreateMCPServer(name={sname!r}, fields={srv_fields!r}),"
+            )
+            for mt in s_tools:
+                tname = mt.get("name") or f"mcp_tool_{mt.get('id')}"
+                t_fields = {
+                    "name": tname,
+                    "description": mt.get("description") or "",
+                    "server": sname,
+                }
+                mcp_tool_ops.append(
+                    f"        migrations.CreateMCPTool(name={tname!r}, fields={t_fields!r}),"
+                )
 
         ops_lines = (
             tool_ops
             + retrieval_tool_ops
+            + mcp_server_ops
+            + mcp_tool_ops
             + [
                 f"        migrations.CreateAgent(name={class_name!r}, fields={agent_fields!r}, meta={meta!r}),"
             ]
@@ -662,8 +1028,29 @@ class {class_name}(BaseAgent):
             class_name = _retrieval_tool_class_name(tool)
             state["remote"]["retrieval_tools"][class_name] = tool.get("id")
 
+        for server_id, s_tools in mcp_server_tool_map.items():
+            server_data = mcp_servers_cache.get(server_id) or {}
+            if not server_data:
+                continue
+            sname = server_data.get("name") or f"mcp_server_{server_id}"
+            state.setdefault("remote", {}).setdefault("mcp_servers", {})[sname] = server_id
+            srv_cls = _mcp_server_class_name(server_data)
+            state["remote"]["mcp_servers"][srv_cls] = server_id
+            for mt in s_tools:
+                tname = mt.get("name") or mt.get("id")
+                state.setdefault("remote", {}).setdefault("mcp_tools", {})[tname] = mt.get("id")
+                tool_cls = _mcp_tool_class_name_from_data(mt)
+                state["remote"]["mcp_tools"][tool_cls] = mt.get("id")
+
         # Populate local state snapshot directly from project code
-        state["state"] = collect_definitions(project_path, app)
+        try:
+            state["state"] = collect_definitions(project_path, app)
+        except Exception as exc:
+            print(
+                f"  Warning: could not build full state snapshot ({exc}). "
+                "The import succeeded but .state.json local state may be incomplete. "
+                "Re-import any agents that reference undefined classes."
+            )
         state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
         # ------------------------------------------------------------------
@@ -739,10 +1126,104 @@ class {class_name}(BaseAgent):
             imported_topics: dict[str, dict[str, Any]] = {}
             imported_formatters: dict[str, dict[str, Any]] = {}
             imported_retrievals: dict[str, dict[str, Any]] = {}
+            imported_metadata_cfgs: dict[str, dict[str, Any]] = {}
             remote_topics: dict[str, int] = {}
             remote_formatters: dict[str, int] = {}
             remote_retrievals: dict[str, int] = {}
+            remote_metadata_cfgs: dict[str, int] = {}
             formatter_class_names: dict[int, str] = {}
+            metadata_nodes_done: set[int] = set()
+            metadata_type_names = {"STRING", "INTEGER", "FLOAT", "BOOLEAN", "DATE", "URL"}
+
+            def _import_node_metadata_configs(
+                node: dict[str, Any], node_path: str, module_dir: Path
+            ) -> None:
+                """Fetch a node's metadata configs and generate data/<topic>/metadata.py."""
+                node_id = node.get("id")
+                if not isinstance(node_id, int) or node_id in metadata_nodes_done:
+                    return
+                metadata_nodes_done.add(node_id)
+                try:
+                    payload = client.list_metadata_configs(node_id)
+                except CogSolAPIError as exc:
+                    print(f"  Warning: could not list metadata configs for node {node_id}: {exc}")
+                    return
+                if isinstance(payload, dict):
+                    items = payload.get("results") or payload.get("metadata_configs") or []
+                elif isinstance(payload, list):
+                    items = payload
+                else:
+                    items = []
+
+                metadata_file = module_dir / "metadata.py"
+                for cfg in items:
+                    if not isinstance(cfg, dict) or not cfg.get("name"):
+                        continue
+                    # Skip configs inherited from an ancestor node.
+                    root_node_id = cfg.get("root_node_id")
+                    if isinstance(root_node_id, int) and root_node_id != node_id:
+                        continue
+                    cfg_name = str(cfg["name"])
+                    cfg_type = str(cfg.get("type") or "STRING").upper()
+                    type_expr = (
+                        f"MetadataType.{cfg_type}"
+                        if cfg_type in metadata_type_names
+                        else repr(cfg.get("type"))
+                    )
+                    cls_base = _safe_class_name(cfg_name, "Metadata")
+                    cls_name = (
+                        cls_base if cls_base.endswith("Metadata") else cls_base + "Metadata"
+                    )
+                    lines = [
+                        f"class {cls_name}(BaseMetadataConfig):",
+                        f"    name = {cfg_name!r}",
+                        f"    type = {type_expr}",
+                    ]
+                    if cfg.get("possible_values"):
+                        lines.append(f"    possible_values = {list(cfg['possible_values'])!r}")
+                    if cfg.get("default_value") is not None:
+                        lines.append(f"    default_value = {cfg.get('default_value')!r}")
+                    if cfg.get("format"):
+                        lines.append(f"    format = {cfg.get('format')!r}")
+                    if cfg.get("filtrable"):
+                        lines.append("    filtrable = True")
+                    if cfg.get("required"):
+                        lines.append("    required = True")
+                    if cfg.get("in_embedding"):
+                        lines.append("    in_embedding = True")
+                    if cfg.get("in_retrieval") is False:
+                        lines.append("    in_retrieval = False")
+
+                    _ensure_import(
+                        metadata_file,
+                        "from cogsol.content import BaseMetadataConfig, MetadataType",
+                    )
+                    if _append_block(
+                        metadata_file,
+                        "\n".join(lines),
+                        f"class {cls_name}(BaseMetadataConfig):",
+                    ):
+                        import_messages.append(
+                            f"Metadata config: {node_path}/{cfg_name} -> {metadata_file}"
+                        )
+
+                    cfg_key = f"{node_path}/{cfg_name}"
+                    imported_metadata_cfgs[cfg_key] = {
+                        "fields": {
+                            "name": cfg_name,
+                            "type": cfg_type,
+                            "possible_values": list(cfg.get("possible_values") or []),
+                            "default_value": cfg.get("default_value"),
+                            "format": cfg.get("format"),
+                            "filtrable": bool(cfg.get("filtrable", False)),
+                            "required": bool(cfg.get("required", False)),
+                            "in_embedding": bool(cfg.get("in_embedding", False)),
+                            "in_retrieval": bool(cfg.get("in_retrieval", True)),
+                        },
+                        "topic": node_path,
+                    }
+                    if isinstance(cfg.get("id"), int):
+                        remote_metadata_cfgs[cfg_key] = int(cfg["id"])
 
             for retrieval_id in sorted(retrieval_ids):
                 try:
@@ -796,6 +1277,7 @@ class {class_name}(BaseAgent):
                             }
                             if isinstance(node.get("id"), int):
                                 remote_topics[node_path] = int(node["id"])
+                            _import_node_metadata_configs(node, node_path, module_dir)
 
                 # Formatters used by retrieval
                 formatters_value = {}
@@ -946,7 +1428,12 @@ class {class_name}(BaseAgent):
                 if isinstance(retrieval.get("id"), int):
                     remote_retrievals[retrieval_name] = int(retrieval["id"])
 
-            if imported_topics or imported_formatters or imported_retrievals:
+            if (
+                imported_topics
+                or imported_formatters
+                or imported_retrievals
+                or imported_metadata_cfgs
+            ):
                 data_migrations = data_path / "migrations"
                 data_migrations.mkdir(parents=True, exist_ok=True)
                 data_mig_name = next_migration_name(data_migrations, explicit_name=f"import_{slug}")
@@ -957,6 +1444,11 @@ class {class_name}(BaseAgent):
                     ops_lines.append(
                         f"        migrations.CreateTopic(name={topic_key!r}, "
                         f"fields={definition['fields']!r}, meta={definition['meta']!r}),"
+                    )
+                for cfg_key, definition in imported_metadata_cfgs.items():
+                    ops_lines.append(
+                        f"        migrations.CreateMetadataConfig(name={cfg_key!r}, "
+                        f"fields={definition['fields']!r}, topic={definition['topic']!r}),"
                     )
                 for fmt_name, definition in imported_formatters.items():
                     ops_lines.append(
@@ -1013,6 +1505,9 @@ class {class_name}(BaseAgent):
                 )
                 data_state.setdefault("remote", {}).setdefault("retrievals", {}).update(
                     remote_retrievals
+                )
+                data_state.setdefault("remote", {}).setdefault("metadata_configs", {}).update(
+                    remote_metadata_cfgs
                 )
 
                 data_state["state"] = _strip_class_refs(

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -18,7 +18,12 @@ from cogsol.core.constants import (
     get_cognitive_api_base_url,
     get_content_api_base_url,
 )
-from cogsol.core.loader import _extract_tool_params, collect_classes, collect_content_classes
+from cogsol.core.loader import (
+    _extract_tool_params,
+    collect_classes,
+    collect_content_classes,
+    collect_content_definitions,
+)
 from cogsol.db import migrations
 from cogsol.management.base import BaseCommand
 from cogsol.prompts import Prompt
@@ -947,6 +952,103 @@ class Command(BaseCommand):
             "code": code,
         }
 
+    def _search_filters_payload(
+        self,
+        *,
+        tool_name: str,
+        filters_value: Any,
+        project_path: Path,
+    ) -> list[dict[str, Any]]:
+        """Resolve ``BaseRetrievalTool.filters`` entries into Cognitive filter payloads.
+
+        Each entry may be a metadata config name ("author"), a topic-qualified
+        name ("product_docs/author"), a BaseMetadataConfig subclass, a remote
+        metadata config id (int), or a raw dict (passed through).  Resolution
+        uses the local ``data/`` definitions plus the remote ids stored in
+        ``data/migrations/.state.json``.
+        """
+        refs = list(filters_value or [])
+        if not refs:
+            return []
+
+        try:
+            content_defs = collect_content_definitions(project_path, "data")
+            metadata_defs = content_defs.get("metadata_configs", {}) or {}
+        except Exception:
+            metadata_defs = {}
+
+        try:
+            state_path = project_path / "data" / "migrations" / ".state.json"
+            _, remote = self._load_content_state(state_path)
+            remote_cfg_ids = remote.get("metadata_configs", {}) or {}
+        except Exception:
+            remote_cfg_ids = {}
+
+        def _entry(cfg_key: str, fields: dict[str, Any]) -> dict[str, Any]:
+            remote_id = remote_cfg_ids.get(cfg_key)
+            if remote_id is None:
+                raise CogSolAPIError(
+                    f"Filter '{cfg_key}' on retrieval tool '{tool_name}' has no migrated "
+                    "metadata config id. Run 'python manage.py migrate data' first."
+                )
+            entry: dict[str, Any] = {
+                "metadata_config_id": int(remote_id),
+                "name": fields.get("name") or cfg_key.rsplit("/", 1)[-1],
+                "type": str(fields.get("type") or "STRING").lower(),
+            }
+            possible_values = fields.get("possible_values") or []
+            if possible_values:
+                entry["possible_values"] = list(possible_values)
+            if fields.get("format"):
+                entry["format"] = fields["format"]
+            return entry
+
+        resolved: list[dict[str, Any]] = []
+        for ref in refs:
+            if isinstance(ref, dict):
+                resolved.append(ref)
+                continue
+            if isinstance(ref, int):
+                by_id = [
+                    key
+                    for key, rid in remote_cfg_ids.items()
+                    if rid == ref and key in metadata_defs
+                ]
+                if not by_id:
+                    raise CogSolAPIError(
+                        f"Filter id {ref} on retrieval tool '{tool_name}' does not match "
+                        "any migrated metadata config. Use the metadata config name instead."
+                    )
+                cfg_key = by_id[0]
+                resolved.append(_entry(cfg_key, metadata_defs[cfg_key].get("fields", {})))
+                continue
+
+            if isinstance(ref, type):
+                ref_name = getattr(ref, "name", None) or ref.__name__
+            else:
+                ref_name = str(ref)
+
+            if ref_name in metadata_defs:
+                matches = [ref_name]
+            else:
+                matches = [
+                    key for key in metadata_defs if key.rsplit("/", 1)[-1] == ref_name
+                ]
+            if not matches:
+                raise CogSolAPIError(
+                    f"Filter '{ref_name}' on retrieval tool '{tool_name}' does not match "
+                    "any metadata config defined in data/. Define it in the topic's "
+                    "metadata.py (with filtrable = True) and migrate the data app first."
+                )
+            if len(matches) > 1:
+                raise CogSolAPIError(
+                    f"Filter '{ref_name}' on retrieval tool '{tool_name}' is ambiguous: "
+                    f"{', '.join(sorted(matches))}. Use 'topic/name' to disambiguate."
+                )
+            cfg_key = matches[0]
+            resolved.append(_entry(cfg_key, metadata_defs[cfg_key].get("fields", {})))
+        return resolved
+
     def _retrieval_tool_payload(
         self,
         *,
@@ -1001,6 +1103,11 @@ class Command(BaseCommand):
             "name": _get("name") or tool_name,
             "description": description,
             "parameters": params,
+            "filters": self._search_filters_payload(
+                tool_name=tool_name,
+                filters_value=_get("filters"),
+                project_path=project_path,
+            ),
             "show_tool_message": bool(_get("show_tool_message", False)),
             "show_assistant_message": bool(_get("show_assistant_message", False)),
             "edit_available": bool(_get("edit_available", True)),
@@ -1133,15 +1240,16 @@ class Command(BaseCommand):
             if remote_id:
                 pretool_ids.append(remote_id)
 
+        # The chat frontend reads camelCase keys from the colors JSON.
         colors = {}
         if _get_meta("assistant_name_color"):
-            colors["assistant_name_color"] = _get_meta("assistant_name_color")
+            colors["nameColor"] = _get_meta("assistant_name_color")
         if _get_meta("primary_color"):
-            colors["primary_color"] = _get_meta("primary_color")
+            colors["primaryColor"] = _get_meta("primary_color")
         if _get_meta("secondary_color"):
-            colors["secondary_color"] = _get_meta("secondary_color")
+            colors["secondaryColor"] = _get_meta("secondary_color")
         if _get_meta("border_color"):
-            colors["border_color"] = _get_meta("border_color")
+            colors["borderColor"] = _get_meta("border_color")
 
         payload = {
             "generation_config": _normalize_config(_get("generation_config")),
@@ -1177,7 +1285,7 @@ class Command(BaseCommand):
                 getattr(cls, "lessons", []) if cls else fields.get("lessons")
             ),
             "realtime_available": bool(_get("realtime", False)),
-            "info": None,
+            "info": _get_meta("alias") or None,
             "colors": colors,
             "logo": _get_meta("logo_url"),
             "streaming_available": bool(_get("streaming", False)),

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -1031,9 +1031,7 @@ class Command(BaseCommand):
             if ref_name in metadata_defs:
                 matches = [ref_name]
             else:
-                matches = [
-                    key for key in metadata_defs if key.rsplit("/", 1)[-1] == ref_name
-                ]
+                matches = [key for key in metadata_defs if key.rsplit("/", 1)[-1] == ref_name]
             if not matches:
                 raise CogSolAPIError(
                     f"Filter '{ref_name}' on retrieval tool '{tool_name}' does not match "

--- a/cogsol/management/commands/startagent.py
+++ b/cogsol/management/commands/startagent.py
@@ -27,6 +27,13 @@ class {class_name}(BaseAgent):
     class Meta:
         name = "{class_name}"
         chat_name = "{class_name}"
+        # Chat personalization (optional):
+        # alias = "{class_name}"              # name shown in the chat UI
+        # logo_url = "https://.../logo.png"
+        # assistant_name_color = "#FFFFFF"
+        # primary_color = "#1A3C5E"
+        # secondary_color = "#00B4CC"
+        # border_color = "#2E6D8E"
 """
 
 FAQS_TEMPLATE = """\

--- a/cogsol/management/commands/startproject.py
+++ b/cogsol/management/commands/startproject.py
@@ -349,6 +349,17 @@ class Command(BaseCommand):
                 materialize_cookbook(source_dir, target_dir, force=force)
             except CookbookError as exc:
                 print(f"Error: {exc}")
+                if "not found" in str(exc):
+                    try:
+                        entries = list_cookbook_entries(
+                            kind, ref=ref, repo=repo, github_token=github_token
+                        )
+                    except CookbookError:
+                        entries = []
+                    if entries:
+                        print(f"Available {kind} in {repo}@{ref}:")
+                        for entry in entries:
+                            print(f"  - {entry}")
                 return 1
 
             # Add default .env.example if the cookbook entry does not provide one

--- a/cogsol/tools/__init__.py
+++ b/cogsol/tools/__init__.py
@@ -65,6 +65,11 @@ class BaseRetrievalTool:
     show_assistant_message: bool = False
     edit_available: bool = True
     answer: bool = True
+    # Metadata filters assigned to this search. Entries can be metadata config
+    # names ("author"), topic-qualified names ("product_docs/author"), or
+    # BaseMetadataConfig subclasses. They are resolved to Cognitive filter
+    # definitions on migrate.
+    filters: list[Any] | None = None
 
     def __init__(self, name: str | None = None, description: str | None = None):
         if name:
@@ -76,6 +81,7 @@ class BaseRetrievalTool:
             self.name = cls_name[:-4] if cls_name.endswith("Tool") else cls_name
         # Avoid sharing mutable metadata across subclasses/instances.
         self.parameters = list(getattr(self, "parameters", []) or [])
+        self.filters = list(getattr(self, "filters", []) or [])
 
     def __repr__(self) -> str:
         return f"<RetrievalTool {self.name or self.__class__.__name__}>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ select = ["E", "F", "W", "I", "UP", "B", "C4"]
 ignore = ["E501", "UP007"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -447,7 +447,9 @@ class TestFetchCookbookDirectory:
             _mock_urlopen(fresh),
             mock.patch("cogsol.core.cookbook.CACHE_DIR", tmp_path),
         ):
-            with pytest.raises(CookbookError, match=r"'templates/demo' not found in owner/repo@main"):
+            with pytest.raises(
+                CookbookError, match=r"'templates/demo' not found in owner/repo@main"
+            ):
                 fetch_cookbook_directory("templates", "demo", ref="main", repo="owner/repo")
 
 

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -401,6 +401,55 @@ class TestFetchCookbookDirectory:
             assert (result / "main.py").read_text() == "code"
             assert (result / "README.md").read_text() == "docs"
 
+    def test_stale_cache_refetches_when_entry_missing(self, tmp_path):
+        """A template pushed after the tarball was cached must still resolve.
+
+        Reproduces the reopened issue: the user tests an example (tarball gets
+        cached), then pushes a new template to their repo — the cached tarball
+        does not contain it yet.
+        """
+        stale = _make_tarball({"owner-repo-old/examples/hello/app.py": "# app"})
+        fresh = _make_tarball(
+            {
+                "owner-repo-new/examples/hello/app.py": "# app",
+                "owner-repo-new/templates/demo/main.py": "# demo",
+            }
+        )
+        with mock.patch("cogsol.core.cookbook.CACHE_DIR", tmp_path):
+            cached = tmp_path / "tarballs" / "owner--repo-main.tar.gz"
+            cached.parent.mkdir(parents=True)
+            cached.write_bytes(stale)  # recent mtime -> considered fresh
+
+            with _mock_urlopen(fresh) as mock_url:
+                result = fetch_cookbook_directory(
+                    "templates", "demo", ref="main", repo="owner/repo"
+                )
+            assert (result / "main.py").read_text() == "# demo"
+            assert mock_url.called
+
+    def test_sha_ref_does_not_refetch(self, tmp_path):
+        """SHA refs are immutable — a missing entry must fail without retrying."""
+        stale = _make_tarball({"owner-repo-old/examples/hello/app.py": "# app"})
+        sha = "a" * 40
+        with mock.patch("cogsol.core.cookbook.CACHE_DIR", tmp_path):
+            cached = tmp_path / "tarballs" / f"owner--repo-{sha}.tar.gz"
+            cached.parent.mkdir(parents=True)
+            cached.write_bytes(stale)
+
+            with mock.patch("cogsol.core.cookbook.request.urlopen") as mock_url:
+                with pytest.raises(CookbookError, match="not found"):
+                    fetch_cookbook_directory("templates", "demo", ref=sha, repo="owner/repo")
+                mock_url.assert_not_called()
+
+    def test_not_found_error_includes_repo_and_ref(self, tmp_path):
+        fresh = _make_tarball({"owner-repo-new/examples/hello/app.py": "# app"})
+        with (
+            _mock_urlopen(fresh),
+            mock.patch("cogsol.core.cookbook.CACHE_DIR", tmp_path),
+        ):
+            with pytest.raises(CookbookError, match=r"'templates/demo' not found in owner/repo@main"):
+                fetch_cookbook_directory("templates", "demo", ref="main", repo="owner/repo")
+
 
 # ---------------------------------------------------------------------------
 # Integration tests — startproject command
@@ -729,3 +778,33 @@ class TestStartprojectCookbook:
                 ref="main",
             )
         assert result == 1
+
+    def test_not_found_lists_available_entries(self, tmp_path, capsys):
+        cmd = StartprojectCommand()
+        project_dir = tmp_path / "myproject"
+        with (
+            mock.patch(
+                "cogsol.management.commands.startproject.fetch_cookbook_directory",
+                side_effect=CookbookError("'templates/bad' not found in owner/repo@main."),
+            ),
+            mock.patch(
+                "cogsol.management.commands.startproject.list_cookbook_entries",
+                return_value=["demo", "rag-agent"],
+            ),
+        ):
+            result = cmd.handle(
+                project_path=None,
+                name="myproject",
+                directory=str(project_dir),
+                from_template="bad",
+                from_example=None,
+                list_templates=False,
+                list_examples=False,
+                force=False,
+                ref="main",
+                cookbook_repo="owner/repo",
+            )
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "demo" in out
+        assert "rag-agent" in out

--- a/tests/test_loader_missing_deps.py
+++ b/tests/test_loader_missing_deps.py
@@ -22,11 +22,15 @@ def _make_project(tools_source: str) -> Path:
 
 def test_collects_definitions_when_tools_import_missing_package(capsys):
     """A module-level import of a package that only exists in Cognitive
-    (e.g. django) must not break definition collection."""
+    (e.g. django) must not break definition collection.
+
+    Uses a package name guaranteed to be missing so the test does not depend
+    on which packages happen to be installed in the environment.
+    """
     project = _make_project(
         "from cogsol.tools import BaseTool\n"
-        "from django.utils import timezone\n"
-        "import django.conf\n"
+        "from cognitive_only_pkg_xyz.utils import timezone\n"
+        "import cognitive_only_pkg_xyz.conf\n"
         "\n"
         "class ServerTimeTool(BaseTool):\n"
         "    description = 'Returns server time'\n"
@@ -39,7 +43,7 @@ def test_collects_definitions_when_tools_import_missing_package(capsys):
 
     assert "ServerTime" in definitions["tools"]
     out = capsys.readouterr().out
-    assert "django" in out
+    assert "cognitive_only_pkg_xyz" in out
     assert "stubbed" in out.lower()
 
 

--- a/tests/test_loader_missing_deps.py
+++ b/tests/test_loader_missing_deps.py
@@ -1,0 +1,77 @@
+"""Tests for collecting definitions when tool code imports packages
+that are not installed locally (they only exist in the Cognitive runtime).
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cogsol.core.loader import collect_definitions
+
+
+def _make_project(tools_source: str) -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    agents = tmp / "agents"
+    agents.mkdir(parents=True)
+    (agents / "__init__.py").write_text("", encoding="utf-8")
+    (agents / "tools.py").write_text(tools_source, encoding="utf-8")
+    return tmp
+
+
+def test_collects_definitions_when_tools_import_missing_package(capsys):
+    """A module-level import of a package that only exists in Cognitive
+    (e.g. django) must not break definition collection."""
+    project = _make_project(
+        "from cogsol.tools import BaseTool\n"
+        "from django.utils import timezone\n"
+        "import django.conf\n"
+        "\n"
+        "class ServerTimeTool(BaseTool):\n"
+        "    description = 'Returns server time'\n"
+        "\n"
+        "    def run(self, chat=None, data=None, secrets=None, log=None):\n"
+        "        return str(timezone.now())\n"
+    )
+
+    definitions = collect_definitions(project, "agents")
+
+    assert "ServerTime" in definitions["tools"]
+    out = capsys.readouterr().out
+    assert "django" in out
+    assert "stubbed" in out.lower()
+
+
+def test_stub_modules_do_not_leak_into_sys_modules():
+    project = _make_project(
+        "from cogsol.tools import BaseTool\n"
+        "import some_missing_package_xyz\n"
+        "\n"
+        "class LeakCheckTool(BaseTool):\n"
+        "    description = 'x'\n"
+        "\n"
+        "    def run(self, chat=None, data=None, secrets=None, log=None):\n"
+        "        return some_missing_package_xyz.do()\n"
+    )
+
+    collect_definitions(project, "agents")
+
+    assert "some_missing_package_xyz" not in sys.modules
+
+
+def test_missing_project_module_still_raises():
+    """A typo'd project-local import must remain a hard error."""
+    project = _make_project(
+        "from cogsol.tools import BaseTool\n"
+        "from agents.helpers_typo import something\n"
+        "\n"
+        "class BrokenTool(BaseTool):\n"
+        "    description = 'x'\n"
+        "\n"
+        "    def run(self, chat=None, data=None, secrets=None, log=None):\n"
+        "        return something\n"
+    )
+
+    with pytest.raises(RuntimeError, match="agents.tools"):
+        collect_definitions(project, "agents")


### PR DESCRIPTION
## MCP server management, search filters, and import/scaffolding fixes

## Description

This PR adds full lifecycle management for MCP servers (edit/delete), extends `importagent` to bring MCP servers/tools and search filters into the project, adds metadata-filter support on retrieval tools, and fixes several robustness issues in definition collection and cookbook scaffolding.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**MCP server management (`editmcptools.py`, `deletemcptools.py`, `addmcptools.py`, `core/management.py`, `core/api.py`)**
- Added `editmcptools` command: interactively edit an existing MCP server (name, description, URL, auth type, credentials) with current values pre-filled. On rename it updates the class name, import lines, `server =` references, and renames the `.env` var prefix instead of duplicating entries. Old tool classes are removed and re-created — no more duplicated classes or env vars when editing.
- Added `deletemcptools` command: deletes an MCP server and its tools from Cognitive, removes the classes from `mcp_servers.py`/`mcp_tools.py` (AST-based removal), cleans the related `.env` vars, and updates `.state.json`.
- Tool discovery in `editmcptools` falls back to the Cognitive API when a direct MCP connection is not possible (e.g. Cloudflare blocks non-browser clients), starting the OAuth browser flow when required. If no tools can be discovered, existing tool definitions are kept (with confirmation) instead of being silently deleted.
- `addmcptools`/`editmcptools`/`deletemcptools` now resolve the API base URL through `get_cognitive_api_base_url()` (env override + `COGSOL_ENV` defaults) instead of requiring a raw `COGSOL_API_BASE` env var.
- Added `get_mcp_tool()` / `delete_mcp_tool()` client methods.

**MCP import (`importagent.py`)**
- Importing an agent now also imports its MCP servers and tools: generates the `BaseMCPServer`/`BaseMCPTool` classes, adds `.env` credential placeholders, emits `CreateMCPServer`/`CreateMCPTool` migration operations, and stores remote IDs in `.state.json`.
- Fixed MCP `server` references returned by the API as strings or nested dicts (`"2"`, `{"id": 2}`) preventing tool class generation.
- Fixed class-existence checks matching commented-out template examples (e.g. `# class AtlassianMCPServer(...)` in the scaffold), which silently skipped generating real classes.
- A failed server fetch now generates a stub server class instead of dropping the tools, and the final state snapshot no longer aborts the whole import if an unrelated agent in the project fails to load.

**Search filters (`tools/__init__.py`, `migrate.py`, `importagent.py`)**
- Added `BaseRetrievalTool.filters`: searches can declare metadata filters by metadata config name (`"author"`), topic-qualified name (`"topic/author"`), or `BaseMetadataConfig` subclass.
- `migrate` resolves them against the local `data/` definitions plus the remote IDs in `data/migrations/.state.json` and sends the filter payload Cognitive expects (`metadata_config_id`, `name`, `type`, `possible_values`, `format`). Clear errors for unknown, unmigrated, or ambiguous filter names.
- `importagent` writes `filters = [...]` on generated search classes, collapsing date filter triplets (`name`/`name_start`/`name_end`) into a single metadata reference, and imports metadata configs for the whole topic chain (skipping configs inherited from ancestor nodes, handling list and paginated payloads, and emitting all config fields including `default_value` — required by migrate for `required=True` configs).

**Agent alias (`agents/__init__.py`, `migrate.py`, `importagent.py`, `startagent.py`)**
- Added `Meta.alias` mapped to the Cognitive `info` field (falls back to `chat_name` when unset).
- `importagent` imports the assistant's alias and colors into the generated `Meta`, reading camelCase color keys with a fallback to legacy snake_case keys from previously framework-migrated assistants.
- `startagent` template now documents the personalization Meta fields.

**Definition collection with missing dependencies (`core/loader.py`)**
- `makemigrations`/`migrate` no longer fail when tool code imports packages that only exist in the Cognitive runtime (e.g. `from django.utils import timezone` at module level). Missing third-party imports are satisfied with inert stub modules during collection, with a visible warning. Stubs never shadow installed packages (finder appended last), never leak into `sys.modules`, and project-local import errors (typos) still fail loudly.

**Cookbook scaffolding (`core/cookbook.py`, `startproject.py`)**
- Fixed `startproject --from-template/--from-example` failing for entries pushed to a custom cookbook repo after the tarball was cached (1h TTL): on "not found" the cache is refreshed once and the fetch retried (branch/tag refs only — SHA refs are immutable).
- The "not found" error now includes `repo@ref`, and the command lists the available templates/examples of that repo to catch typos immediately.

## Testing Done

- [x] Unit tests pass locally (203 passed, including tests from the merged `main`)
- [x] Added `tests/test_loader_missing_deps.py` covering missing-dependency stubbing (collection succeeds with warning, no `sys.modules` leakage, local import typos still raise)
- [x] Added stale-cache, SHA-ref, enriched-error, and available-entries tests in `tests/test_cookbook.py`
- [x] Tested `importagent` manually against a live tenant with MCP tools (Atlassian OAuth server, 11 tools), retrieval tools with filters, and metadata configs
- [x] Tested `editmcptools`/`deletemcptools` manually, including server rename and `.env` prefix migration
- [x] Verified filter round-trip manually: new metadata config + `filters` assignment → `makemigrations` → `migrate` → filter visible on the search in the portal
- [x] Resolved merge with `main` (PR #58): kept superset implementations, adopted `reasoning`/`websearch` and `info` fallback to `chat_name`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
