### PR TITLE
Fix MCP OAuth authorization and server deletions

### DIFF
--- a/cogsol/core/api.py
+++ b/cogsol/core/api.py
@@ -19,6 +19,7 @@ from cogsol.core.constants import (
     get_content_api_base_url,
 )
 from cogsol.core.credentials import ONBOARDING_MESSAGE
+from cogsol.core.http_errors import summarize_http_error
 
 
 class CogSolAPIError(RuntimeError):
@@ -222,8 +223,10 @@ class CogSolClient:
                     content_type=content_type,
                     retry_on_401=False,
                 )
-            detail = exc.read().decode("utf-8", errors="ignore")
-            raise CogSolAPIError(f"{exc.code} {exc.reason}: {detail}") from exc
+            detail = summarize_http_error(exc.read().decode("utf-8", errors="ignore"))
+            if detail:
+                raise CogSolAPIError(f"{exc.code} {exc.reason}: {detail}") from exc
+            raise CogSolAPIError(f"{exc.code} {exc.reason}") from exc
         except error.URLError as exc:  # pragma: no cover - I/O
             raise CogSolAPIError(f"Connection error: {exc.reason}") from exc
 

--- a/cogsol/core/http_errors.py
+++ b/cogsol/core/http_errors.py
@@ -1,0 +1,65 @@
+"""Helpers to render HTTP error bodies as terminal-friendly one-liners.
+
+Remote services answer failures with whatever their stack produces: Cloudflare
+HTML pages, Django debug pages (hundreds of KB), proxy notices.  Printing those
+verbatim buries the actual error, so every error body goes through
+``summarize_http_error`` before reaching the user.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+MAX_DETAIL_LENGTH = 240
+
+
+def _clean_text(raw: str) -> str:
+    """Unescape entities and collapse whitespace into a single line."""
+    return re.sub(r"\s+", " ", html.unescape(raw)).strip()
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= MAX_DETAIL_LENGTH:
+        return text
+    return f"{text[: MAX_DETAIL_LENGTH - 3]}..."
+
+
+def _django_debug_summary(body: str) -> str | None:
+    """Extract ``<exception type> at <path>: <message>`` from a Django debug page."""
+    value_match = re.search(
+        r'<pre class="exception_value">(.*?)</pre>', body, re.IGNORECASE | re.DOTALL
+    )
+    if not value_match:
+        return None
+
+    message = _clean_text(value_match.group(1))
+    title_match = re.search(r"<title>(.*?)</title>", body, re.IGNORECASE | re.DOTALL)
+    where = _clean_text(title_match.group(1)) if title_match else ""
+
+    if where and message:
+        return f"{where}: {message}"
+    return message or where or None
+
+
+def summarize_http_error(detail: str) -> str:
+    """Return a concise, single-line description of an HTTP error body."""
+    clean = (detail or "").strip()
+    if not clean:
+        return ""
+
+    lowered = clean.lower()
+    if "<html" in lowered or "<!doctype html" in lowered:
+        django_summary = _django_debug_summary(clean)
+        if django_summary:
+            return _truncate(django_summary)
+
+        title_match = re.search(r"<title>(.*?)</title>", clean, re.IGNORECASE | re.DOTALL)
+        if title_match:
+            return f"HTML error page returned ({_clean_text(title_match.group(1))})"
+        h1_match = re.search(r"<h1[^>]*>(.*?)</h1>", clean, re.IGNORECASE | re.DOTALL)
+        if h1_match:
+            return f"HTML error page returned ({_clean_text(h1_match.group(1))})"
+        return "HTML error page returned by remote server"
+
+    return _truncate(re.sub(r"\s+", " ", clean))

--- a/cogsol/core/loader.py
+++ b/cogsol/core/loader.py
@@ -52,6 +52,19 @@ def serialize_value(value: Any) -> Any:
     """
     from dataclasses import asdict, is_dataclass
 
+    if isinstance(value, _StubValue):
+        # A stub means the import behind this value never resolved.  Writing its
+        # repr() into a migration produces a file that cannot be parsed, so fail
+        # here with something actionable instead.
+        raise RuntimeError(
+            f"Cannot serialize '{value._stub_name}': the module it comes from could not "
+            "be imported, so a placeholder was used instead of the real object.\n"
+            "  If it is a project module, import it through its app "
+            "(e.g. 'from agents.mcp_tools import MyMCPTool' instead of 'from mcp_tools "
+            "import MyMCPTool').\n"
+            "  If it is a third-party package, install it in this environment."
+        )
+
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     if isinstance(value, Path):
@@ -140,9 +153,27 @@ class _MissingDependencyStubber(importlib.abc.MetaPathFinder, importlib.abc.Load
         if top == "cogsol" or top in stdlib_names:
             return False
         # Never stub project-local modules — a typo there is a real error.
-        if (self.project_path / top).exists() or (self.project_path / f"{top}.py").exists():
+        if self._is_project_local(top):
             return False
         return True
+
+    def _is_project_local(self, top: str) -> bool:
+        """True when ``top`` names a module that belongs to this project."""
+        if (self.project_path / top).exists() or (self.project_path / f"{top}.py").exists():
+            return True
+        # App packages hold modules that are only importable through their app
+        # (``agents.mcp_tools``).  Importing one unqualified (``mcp_tools``) is a
+        # mistake that must surface, not be stubbed into a placeholder value.
+        try:
+            app_dirs = [entry for entry in self.project_path.iterdir() if entry.is_dir()]
+        except OSError:
+            return False
+        for app_dir in app_dirs:
+            if app_dir.name.startswith(".") or app_dir.name.startswith("__"):
+                continue
+            if (app_dir / f"{top}.py").exists() or (app_dir / top).is_dir():
+                return True
+        return False
 
     def find_spec(self, fullname, path=None, target=None):
         if not self._is_stubbable(fullname):

--- a/cogsol/core/mcp.py
+++ b/cogsol/core/mcp.py
@@ -7,10 +7,17 @@ MCP server.  No third-party dependencies are required.
 from __future__ import annotations
 
 import json
-import re
 import uuid
 from typing import Any, cast
 from urllib import error, request
+
+from cogsol import __version__
+from cogsol.core.http_errors import summarize_http_error
+
+# ``urllib`` otherwise announces itself as ``Python-urllib/x.y``, a signature
+# that CDNs in front of public MCP servers (e.g. Cloudflare rule 1010) reject
+# with 403 before the request ever reaches the server.
+DEFAULT_USER_AGENT = f"cogsol-framework/{__version__} (+https://cogsol.ai; MCP client)"
 
 
 class MCPClientError(RuntimeError):
@@ -79,22 +86,58 @@ class MCPClient:
             self.initialized = True
             return True
         except MCPClientError as exc:
-            msg = str(exc)
-            if "HTTP 401" in msg and self.auth_type == "oauth2":
-                print(
-                    "[MCPClient] Received 401 — this OAuth 2.1 server requires user "
-                    "authorization.\n"
-                    "  Tool discovery without auth failed, but you can still create the "
-                    "server definition.\n"
-                    "  Complete the OAuth authorization flow from the CogSol portal after "
-                    "running `migrate`."
-                )
-            else:
-                print(f"[MCPClient] Failed to initialize: {exc}")
+            print(self._describe_initialize_failure(exc))
             return False
         except Exception as exc:
             print(f"[MCPClient] Failed to initialize: {exc}")
             return False
+
+    def _describe_initialize_failure(self, exc: MCPClientError) -> str:
+        """Turn a handshake failure into an explanation instead of a raw payload."""
+        msg = str(exc)
+
+        if "HTTP 401" in msg:
+            if self.auth_type == "oauth2":
+                return (
+                    "[MCPClient] The server answered 401 — it requires user authorization "
+                    "before listing tools.\n"
+                    "  This is expected for OAuth 2.1 servers: discovery continues through "
+                    "the CogSol API,\n"
+                    "  which holds the OAuth tokens."
+                )
+            return (
+                "[MCPClient] The server answered 401 Unauthorized — the credentials sent "
+                "were rejected.\n"
+                "  Check the header values you entered (or whether this server needs "
+                "auth_type='oauth2')."
+            )
+
+        if "HTTP 403" in msg:
+            detail = (
+                "  A CDN or WAF in front of the server blocked the request before it "
+                "reached the MCP endpoint\n"
+                "  (Cloudflare error 1010 means the client signature was rejected)."
+            )
+            if self.auth_type == "oauth2":
+                return (
+                    "[MCPClient] The server answered 403 — a direct connection from here "
+                    "is not allowed.\n" + detail + "\n"
+                    "  Discovery continues through the CogSol API, so this is not fatal."
+                )
+            return (
+                "[MCPClient] The server answered 403 — a direct connection from here is "
+                "not allowed.\n" + detail + "\n"
+                "  Tools cannot be listed; verify the URL and whether the server requires "
+                "specific headers."
+            )
+
+        if "Connection error" in msg:
+            return (
+                f"[MCPClient] Could not reach the server: {msg}\n"
+                "  Check the URL and your network connection."
+            )
+
+        return f"[MCPClient] Failed to initialize: {exc}"
 
     def list_tools(self) -> list[dict[str, Any]]:
         """Return tools discovered during ``initialize``."""
@@ -105,7 +148,10 @@ class MCPClient:
         if not self.session_id:
             return
         try:
-            headers = {"Mcp-Session-Id": self.session_id}
+            headers = {
+                "Mcp-Session-Id": self.session_id,
+                "User-Agent": DEFAULT_USER_AGENT,
+            }
             headers.update(self.extra_headers)
             req = request.Request(self.server_url, headers=headers, method="DELETE")
             with request.urlopen(req, timeout=5):
@@ -120,26 +166,7 @@ class MCPClient:
     @staticmethod
     def _summarize_http_error(detail: str) -> str:
         """Return a concise HTTP error detail suitable for terminal output."""
-        clean = (detail or "").strip()
-        if not clean:
-            return ""
-
-        # Cloudflare / proxy pages often return full HTML documents.
-        if "<html" in clean.lower() or "<!doctype html" in clean.lower():
-            title_match = re.search(r"<title>(.*?)</title>", clean, re.IGNORECASE | re.DOTALL)
-            if title_match:
-                title = re.sub(r"\s+", " ", title_match.group(1)).strip()
-                return f"HTML error page returned ({title})"
-            h1_match = re.search(r"<h1[^>]*>(.*?)</h1>", clean, re.IGNORECASE | re.DOTALL)
-            if h1_match:
-                heading = re.sub(r"\s+", " ", h1_match.group(1)).strip()
-                return f"HTML error page returned ({heading})"
-            return "HTML error page returned by remote server"
-
-        single_line = re.sub(r"\s+", " ", clean)
-        if len(single_line) > 240:
-            return f"{single_line[:237]}..."
-        return single_line
+        return summarize_http_error(detail)
 
     def _make_request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         request_id = str(uuid.uuid4())
@@ -154,9 +181,11 @@ class MCPClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
+            "User-Agent": DEFAULT_USER_AGENT,
         }
         if self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
+        # User-supplied headers win, so a custom User-Agent can still be set.
         headers.update(self.extra_headers)
 
         body = json.dumps(payload).encode("utf-8")

--- a/cogsol/management/commands/addmcptools.py
+++ b/cogsol/management/commands/addmcptools.py
@@ -23,6 +23,7 @@ sent write-only to the CogSol API, which stores it in Azure Key Vault.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import time
@@ -51,6 +52,22 @@ HEADER_KEYS = [
 AUTH_TYPES = ["none", "headers", "oauth2"]
 OAUTH_POLL_SECONDS_DEFAULT = 300
 OAUTH_POLL_INTERVAL_SECONDS = 2
+
+# The API exposes no ``oauth_status`` field — authorization state lives in
+# per-user token records and is only observable through the tools endpoint,
+# which answers 511 + ``mcp_oauth_required`` while the user still has to
+# authorize the server.
+OAUTH_PENDING_MARKERS = (
+    "mcp_oauth_required",
+    "network authentication required",
+    "oauth re-authorization required",
+)
+
+
+def _is_oauth_pending(exc: CogSolAPIError) -> bool:
+    """True when the API says the MCP server still needs user authorization."""
+    text = str(exc).lower()
+    return any(marker in text for marker in OAUTH_PENDING_MARKERS)
 
 
 def _ask(prompt: str, default: str = "") -> str:
@@ -98,6 +115,25 @@ def _oauth_config(client_id: str, scopes: str) -> dict[str, Any]:
     return cfg
 
 
+def _store_server_remote_id(project_path: Path, app: str, server_name: str, server_id: int) -> None:
+    """Record the server's Cognitive id in ``.state.json``.
+
+    MCP servers are published here, not by ``migrate``, so this is the only
+    chance to capture the id.  ``migrate`` needs it later to delete the server
+    when it is removed from the project.
+    """
+    state_path = project_path / app / "migrations" / ".state.json"
+    if not state_path.exists():
+        return
+    try:
+        state: dict[str, Any] = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return
+
+    state.setdefault("remote", {}).setdefault("mcp_servers", {})[server_name] = server_id
+    state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
 class Command(BaseCommand):
     help = "Interactively configure an MCP server and select tools."
 
@@ -139,43 +175,47 @@ class Command(BaseCommand):
         server_name_n = self._norm(server_name)
         server_url_n = self._norm(str(server_url).rstrip("/"))
 
-        exact = [
-            s
-            for s in servers
-            if self._norm(s.get("name")) == server_name_n
-            and self._norm(str(s.get("url", "")).rstrip("/")) == server_url_n
-        ]
-        if exact:
-            return exact[0]
-
+        # The name is part of a server's identity: never adopt a remote server
+        # just because the URL matches.  Several servers may legitimately share
+        # one MCP endpoint, and adopting one would silently rename it and reuse
+        # its OAuth client registration.
         name_match = [s for s in servers if self._norm(s.get("name")) == server_name_n]
-        if len(name_match) == 1:
-            return name_match[0]
+        if not name_match:
+            return None
 
+        # Same name on the same URL wins over a same-name server pointing elsewhere.
         url_match = [
-            s for s in servers if self._norm(str(s.get("url", "")).rstrip("/")) == server_url_n
+            s for s in name_match if self._norm(str(s.get("url", "")).rstrip("/")) == server_url_n
         ]
-        if len(url_match) == 1:
-            return url_match[0]
-
-        # If duplicates exist for the same URL, prefer oauth2 and most recently updated.
-        if len(url_match) > 1:
-            oauth_candidates = [s for s in url_match if self._norm(s.get("auth_type")) == "oauth2"]
-            candidates = oauth_candidates or url_match
-            candidates.sort(
-                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
-                reverse=True,
-            )
+        candidates = url_match or name_match
+        if len(candidates) == 1:
             return candidates[0]
 
-        if len(name_match) > 1:
-            name_match.sort(
-                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
-                reverse=True,
-            )
-            return name_match[0]
+        candidates.sort(
+            key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
+            reverse=True,
+        )
+        return candidates[0]
 
-        return None
+    def _fetch_tools_if_authorized(
+        self,
+        *,
+        client: CogSolClient,
+        server_id: int,
+    ) -> list[dict[str, Any]] | None:
+        """Return the server's tools, or ``None`` while OAuth is still pending.
+
+        ``GET /mcp-servers/{id}/tools/`` connects to the MCP server using the
+        stored token, so a successful response is itself proof that
+        authorization completed — and it carries the tool list in the same
+        round trip.
+        """
+        try:
+            return self._extract_results(client.list_mcp_server_tools(server_id))
+        except CogSolAPIError as exc:
+            if _is_oauth_pending(exc):
+                return None
+            raise
 
     def _wait_for_oauth_connected(
         self,
@@ -183,19 +223,28 @@ class Command(BaseCommand):
         client: CogSolClient,
         server_id: int,
         timeout_seconds: int,
-    ) -> bool:
+    ) -> list[dict[str, Any]] | None:
+        """Poll until the server is authorized, returning its tools.
+
+        Returns ``None`` when the timeout elapses without authorization.
+        """
         start = time.time()
-        while time.time() - start < timeout_seconds:
+        last_error = ""
+        while True:
             try:
-                data = client.get_mcp_server(server_id) or {}
-                status = str(data.get("oauth_status", "")).lower()
-                if status == "connected":
-                    return True
-            except CogSolAPIError:
-                # Keep polling; callback might still be processing.
-                pass
+                tools = self._fetch_tools_if_authorized(client=client, server_id=server_id)
+            except CogSolAPIError as exc:
+                # Keep polling — the callback may still be in flight — but never
+                # swallow the reason silently.
+                if str(exc) != last_error:
+                    last_error = str(exc)
+                    print(f"  Still waiting; last API response: {exc}")
+                tools = None
+            if tools is not None:
+                return tools
+            if time.time() - start >= timeout_seconds:
+                return None
             time.sleep(OAUTH_POLL_INTERVAL_SECONDS)
-        return False
 
     def _is_oauth_reauthorization_error(self, exc: CogSolAPIError) -> bool:
         return "oauth re-authorization required" in str(exc).lower()
@@ -220,12 +269,12 @@ class Command(BaseCommand):
             print("  Could not auto-open browser. Open this URL manually:")
             print(f"  {authorization_url}")
 
-        connected = self._wait_for_oauth_connected(
+        tools = self._wait_for_oauth_connected(
             client=client,
             server_id=server_id,
             timeout_seconds=max(5, int(oauth_timeout)),
         )
-        if not connected:
+        if tools is None:
             raise CogSolAPIError(
                 "OAuth authorization did not complete within timeout. "
                 "Please finish OAuth in browser and retry addmcptools."
@@ -297,17 +346,15 @@ class Command(BaseCommand):
                 print(str(authorization_url))
 
             print(f"Waiting for OAuth completion (timeout: {oauth_timeout}s)...")
-            connected = self._wait_for_oauth_connected(
+            tools = self._wait_for_oauth_connected(
                 client=api_client,
                 server_id=server_id,
                 timeout_seconds=max(5, int(oauth_timeout)),
             )
-            if not connected:
+            if tools is None:
                 print("OAuth authorization timeout. You can retry addmcptools after authorizing.")
                 return []
 
-            tools_payload = api_client.list_mcp_server_tools(server_id)
-            tools = self._extract_results(tools_payload)
             if not tools:
                 print("OAuth connected, but no tools were returned by the MCP server.")
                 return []
@@ -341,7 +388,8 @@ class Command(BaseCommand):
         oauth_scopes: str,
         selected_tools: list[dict[str, Any]],
         oauth_timeout: int,
-    ) -> None:
+    ) -> int:
+        """Publish the server and its tools, returning the server's remote id."""
         api_base = get_cognitive_api_base_url()
         api_key = os.environ.get("COGSOL_API_KEY")
 
@@ -392,9 +440,12 @@ class Command(BaseCommand):
                 else:
                     raise
 
-            server_data = client.get_mcp_server(server_id) or {}
-            status = str(server_data.get("oauth_status", "")).lower()
-            if force_authorization or status != "connected":
+            already_authorized = (
+                False
+                if force_authorization
+                else self._fetch_tools_if_authorized(client=client, server_id=server_id) is not None
+            )
+            if not already_authorized:
                 print("  OAuth server is not connected yet. Starting authorization flow...")
                 self._start_oauth_authorization(
                     client=client,
@@ -406,7 +457,7 @@ class Command(BaseCommand):
         tool_names = [str(t.get("name")) for t in selected_tools if t.get("name")]
         if not tool_names:
             print("  No MCP tools selected to sync in Cognitive.")
-            return
+            return server_id
 
         try:
             client.sync_mcp_server_tools(server_id, tool_names)
@@ -426,6 +477,7 @@ class Command(BaseCommand):
             )
             client.sync_mcp_server_tools(server_id, tool_names)
         print(f"  Synced {len(tool_names)} MCP tool(s) in Cognitive.")
+        return server_id
 
     def handle(self, project_path: Path | None, **options: Any) -> int:  # noqa: C901
         assert project_path is not None, "project_path is required"
@@ -787,7 +839,7 @@ class Command(BaseCommand):
             "(this updates what appears in the portal immediately)..."
         )
         try:
-            self._publish_to_cognitive(
+            server_id = self._publish_to_cognitive(
                 server_name=server_name,
                 server_description=server_description,
                 server_url=server_url,
@@ -802,6 +854,8 @@ class Command(BaseCommand):
         except CogSolAPIError as exc:
             print(f"Failed to publish MCP catalog to Cognitive: {exc}")
             return 1
+
+        _store_server_remote_id(project_path, app, server_name, server_id)
 
         if auth_type == "oauth2" and oauth_client_secret:
             print(

--- a/cogsol/management/commands/deletemcptools.py
+++ b/cogsol/management/commands/deletemcptools.py
@@ -6,23 +6,25 @@ Workflow
 2.  User selects a server to remove.
 3.  All tool classes in ``agents/mcp_tools.py`` that reference that server
     are shown for confirmation.
-4.  On confirmation:
-    - Deletes the server from the CogSol API.
+4.  On confirmation, the project is updated:
     - Removes the server class from ``mcp_servers.py``.
     - Removes the associated tool classes from ``mcp_tools.py``.
+    - Removes references to those tools (and their imports) from every
+      ``agent.py``, so the project still imports afterwards.
     - Removes the related env vars from ``.env``.
+
+Nothing is deleted in Cognitive by this command.  The project is the source of
+truth, so the removal is published by ``makemigrations`` + ``migrate`` like any
+other change; the remote ids stay in ``.state.json`` until then.
 """
 
 from __future__ import annotations
 
 import ast
 import json
-import os
 from pathlib import Path
 from typing import Any
 
-from cogsol.core.api import CogSolAPIError, CogSolClient
-from cogsol.core.constants import get_cognitive_api_base_url
 from cogsol.core.loader import collect_classes
 from cogsol.management.base import BaseCommand
 from cogsol.management.commands.addmcptools import (
@@ -55,6 +57,122 @@ def _remove_class_from_source(source: str, class_name: str) -> tuple[str, bool]:
             return "".join(lines[:start] + lines[end:]), True
 
     return source, False
+
+
+def _element_class_name(node: ast.expr) -> str | None:
+    """Return the class name an element of a ``tools`` list refers to.
+
+    Handles both ``MyTool()`` and a bare ``MyTool``.
+    """
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _span(source_lines: list[str], node: ast.expr | ast.stmt) -> tuple[int, int]:
+    """Return the ``(start, end)`` character offsets of a node."""
+    offsets = [0]
+    for line in source_lines:
+        offsets.append(offsets[-1] + len(line))
+    start = offsets[node.lineno - 1] + node.col_offset
+    end = offsets[(node.end_lineno or node.lineno) - 1] + (node.end_col_offset or 0)
+    return start, end
+
+
+def _remove_tool_references(source: str, class_names: set[str]) -> tuple[str, list[str]]:
+    """Drop the given tool classes from ``tools``/``pretools`` lists and imports.
+
+    Returns ``(new_source, removed_names)``.  Formatting of the surviving
+    entries is preserved: single-line lists stay on one line, multi-line lists
+    keep one entry per line.
+    """
+    if not class_names:
+        return source, []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source, []
+
+    lines = source.splitlines(keepends=True)
+    removed: list[str] = []
+    # (start, end, replacement), applied back-to-front so offsets stay valid.
+    edits: list[tuple[int, int, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.List):
+            targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if not targets & {"tools", "pretools"}:
+                continue
+
+            keep: list[str] = []
+            dropped: list[str] = []
+            for element in node.value.elts:
+                name = _element_class_name(element)
+                if name and name in class_names:
+                    dropped.append(name)
+                    continue
+                el_start, el_end = _span(lines, element)
+                keep.append(source[el_start:el_end])
+            if not dropped:
+                continue
+            removed.extend(dropped)
+
+            list_start, list_end = _span(lines, node.value)
+            original = source[list_start:list_end]
+            if not keep:
+                replacement = "[]"
+            elif "\n" in original:
+                indent = " " * (node.col_offset + 4)
+                body = "".join(f"{indent}{entry},\n" for entry in keep)
+                replacement = "[\n" + body + " " * node.col_offset + "]"
+            else:
+                replacement = "[" + ", ".join(keep) + "]"
+            edits.append((list_start, list_end, replacement))
+
+        elif isinstance(node, ast.ImportFrom) and (node.module or "").endswith("mcp_tools"):
+            surviving = [alias for alias in node.names if alias.name not in class_names]
+            if len(surviving) == len(node.names):
+                continue
+            start, end = _span(lines, node)
+            if surviving:
+                names = ", ".join(
+                    alias.name + (f" as {alias.asname}" if alias.asname else "")
+                    for alias in surviving
+                )
+                edits.append((start, end, f"from {node.module} import {names}"))
+            else:
+                # Drop the whole statement, including its trailing newline.
+                line_end = end
+                while line_end < len(source) and source[line_end] != "\n":
+                    line_end += 1
+                edits.append((start, min(line_end + 1, len(source)), ""))
+
+    if not edits:
+        return source, []
+
+    new_source = source
+    for start, end, replacement in sorted(edits, reverse=True):
+        new_source = new_source[:start] + replacement + new_source[end:]
+    return new_source, removed
+
+
+def _clean_agent_references(app_path: Path, class_names: set[str]) -> list[tuple[Path, list[str]]]:
+    """Remove references to the given tool classes from every agent module."""
+    candidates = sorted(app_path.glob("*/agent.py"))
+    flat_agent = app_path / "agent.py"
+    if flat_agent.exists():
+        candidates.append(flat_agent)
+
+    cleaned: list[tuple[Path, list[str]]] = []
+    for agent_file in candidates:
+        source = agent_file.read_text(encoding="utf-8")
+        new_source, removed = _remove_tool_references(source, class_names)
+        if removed:
+            agent_file.write_text(new_source, encoding="utf-8")
+            cleaned.append((agent_file, removed))
+    return cleaned
 
 
 def _find_server_env_prefix(server_name: str) -> str:
@@ -204,42 +322,9 @@ class Command(BaseCommand):
             print("Cancelled.")
             return 0
 
-        # ── Delete from CogSol API ────────────────────────────────────
-        api_base = get_cognitive_api_base_url()
-        api_key = os.environ.get("COGSOL_API_KEY")
-        if api_base:
-            client = CogSolClient(base_url=api_base, api_key=api_key)
-            # Find remote server by name (same approach as addmcptools)
-            try:
-                servers_remote = client.list_mcp_servers()
-                results = (
-                    servers_remote
-                    if isinstance(servers_remote, list)
-                    else (servers_remote or {}).get("results", [])
-                )
-                server_url = getattr(server_cls, "url", "") or ""
-                remote_entry = next(
-                    (
-                        s
-                        for s in results
-                        if isinstance(s, dict)
-                        and (
-                            str(s.get("name", "")).strip().casefold()
-                            == server_real_name.strip().casefold()
-                            or str(s.get("url", "")).rstrip("/") == str(server_url).rstrip("/")
-                        )
-                    ),
-                    None,
-                )
-                if remote_entry and remote_entry.get("id"):
-                    client.delete_mcp_server(int(remote_entry["id"]))
-                    print(f"  Deleted MCP server from Cognitive (id={remote_entry['id']}).")
-                else:
-                    print("  Warning: MCP server not found in Cognitive; skipping API deletion.")
-            except CogSolAPIError as exc:
-                print(f"  Warning: could not delete server from API: {exc}")
-        else:
-            print("  COGSOL_API_BASE not set — skipping API deletion.")
+        # Nothing is deleted in Cognitive here: the project is the source of
+        # truth, so the removal travels through a migration like any other
+        # change.  ``migrate`` applies it using the ids kept in .state.json.
 
         # ── Remove server class from mcp_servers.py ──────────────────
         servers_file = project_path / app / "mcp_servers.py"
@@ -267,6 +352,14 @@ class Command(BaseCommand):
             source = source.replace(import_line + "\n", "").replace(import_line, "")
             tools_file.write_text(source, encoding="utf-8")
 
+        # ── Remove references from the agents that used those tools ───
+        tool_class_names = {cls.__name__ for cls in server_tools.values()}
+        for agent_file, removed_names in _clean_agent_references(
+            project_path / app, tool_class_names
+        ):
+            names = ", ".join(sorted(set(removed_names)))
+            print(f"  Removed {names} from {agent_file.relative_to(project_path)}")
+
         # ── Clean .env ────────────────────────────────────────────────
         env_path = project_path / ".env"
         prefix = _find_server_env_prefix(server_real_name)
@@ -285,16 +378,9 @@ class Command(BaseCommand):
             except json.JSONDecodeError:
                 state = {}
 
-            remote = state.get("remote", {})
-            mcp_srv = remote.get("mcp_servers", {})
-            for k in list(mcp_srv.keys()):
-                if k in (server_key, server_real_name, server_cls.__name__):
-                    del mcp_srv[k]
-
-            mcp_tools_remote = remote.get("mcp_tools", {})
-            for tool_name in server_tools:
-                mcp_tools_remote.pop(tool_name, None)
-
+            # The remote ids are deliberately kept: 'migrate' needs them to
+            # delete the server and its tools in Cognitive, and drops them
+            # afterwards.
             local_state = state.get("state", {})
             local_state.get("mcp_servers", {}).pop(server_key, None)
             for tool_name in server_tools:
@@ -304,7 +390,8 @@ class Command(BaseCommand):
             print("  Updated .state.json")
 
         print(
-            "\nDone! Run 'python manage.py makemigrations' followed by "
-            "'python manage.py migrate' to apply the deletion."
+            "\nRemoved from the project. Nothing was deleted in Cognitive yet — run\n"
+            "'python manage.py makemigrations' followed by 'python manage.py migrate' "
+            "to apply it."
         )
         return 0

--- a/cogsol/management/commands/editmcptools.py
+++ b/cogsol/management/commands/editmcptools.py
@@ -162,19 +162,38 @@ def _update_env_file(
 # ---------------------------------------------------------------------------
 
 
+def _is_authorized(*, client: CogSolClient, server_id: int) -> bool:
+    """True when the API can reach the MCP server with the stored OAuth token.
+
+    The API exposes no ``oauth_status`` field; the tools endpoint answers
+    511 + ``mcp_oauth_required`` while authorization is still pending.
+    """
+    try:
+        client.list_mcp_server_tools(server_id)
+        return True
+    except CogSolAPIError as exc:
+        if _is_oauth_required_error(exc):
+            return False
+        raise
+
+
 def _wait_for_oauth_connected(
     *, client: CogSolClient, server_id: int, timeout_seconds: int
 ) -> bool:
     start = time.time()
-    while time.time() - start < timeout_seconds:
+    last_error = ""
+    while True:
         try:
-            data = client.get_mcp_server(server_id) or {}
-            if str(data.get("oauth_status", "")).lower() == "connected":
+            if _is_authorized(client=client, server_id=server_id):
                 return True
-        except CogSolAPIError:
-            pass
+        except CogSolAPIError as exc:
+            # Keep polling, but surface the reason instead of hiding it.
+            if str(exc) != last_error:
+                last_error = str(exc)
+                print(f"  Still waiting; last API response: {exc}")
+        if time.time() - start >= timeout_seconds:
+            return False
         time.sleep(OAUTH_POLL_INTERVAL_SECONDS)
-    return False
 
 
 def _is_oauth_reauth_error(exc: CogSolAPIError) -> bool:
@@ -245,40 +264,23 @@ class Command(BaseCommand):
         name_n = norm(server_name)
         url_n = norm(str(server_url).rstrip("/"))
 
-        exact = [
-            s
-            for s in results
-            if isinstance(s, dict)
-            and norm(s.get("name")) == name_n
-            and norm(str(s.get("url", "")).rstrip("/")) == url_n
-        ]
-        if exact:
-            return exact[0]
-
+        # The name is part of a server's identity: never adopt a remote server
+        # just because the URL matches, or editing one server would silently
+        # take over another that happens to share the same MCP endpoint.
         by_name = [s for s in results if isinstance(s, dict) and norm(s.get("name")) == name_n]
-        if len(by_name) == 1:
-            return by_name[0]
+        if not by_name:
+            return None
 
-        by_url = [
-            s
-            for s in results
-            if isinstance(s, dict) and norm(str(s.get("url", "")).rstrip("/")) == url_n
-        ]
-        if len(by_url) >= 1:
-            by_url.sort(
-                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
-                reverse=True,
-            )
-            return by_url[0]
+        by_url = [s for s in by_name if norm(str(s.get("url", "")).rstrip("/")) == url_n]
+        candidates = by_url or by_name
+        if len(candidates) == 1:
+            return candidates[0]
 
-        if len(by_name) > 1:
-            by_name.sort(
-                key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
-                reverse=True,
-            )
-            return by_name[0]
-
-        return None
+        candidates.sort(
+            key=lambda s: str(s.get("updated_at") or s.get("created_at") or ""),
+            reverse=True,
+        )
+        return candidates[0]
 
     def _discover_tools_via_api(
         self,
@@ -368,7 +370,8 @@ class Command(BaseCommand):
         old_server_name: str,
         old_server_url: str,
         oauth_timeout: int,
-    ) -> None:
+    ) -> int:
+        """Publish the updated server and its tools, returning its remote id."""
         api_base = get_cognitive_api_base_url()
         api_key = os.environ.get("COGSOL_API_KEY")
 
@@ -417,8 +420,7 @@ class Command(BaseCommand):
                     force_auth = True
                 else:
                     raise
-            server_data = client.get_mcp_server(server_id) or {}
-            if force_auth or str(server_data.get("oauth_status", "")).lower() != "connected":
+            if force_auth or not _is_authorized(client=client, server_id=server_id):
                 print("  OAuth not connected yet — starting authorization flow...")
                 _start_oauth_authorization(
                     client=client,
@@ -430,7 +432,7 @@ class Command(BaseCommand):
         tool_names = [str(t.get("name")) for t in selected_tools if t.get("name")]
         if not tool_names:
             print("  No MCP tools selected.")
-            return
+            return server_id
 
         try:
             client.sync_mcp_server_tools(server_id, tool_names)
@@ -443,6 +445,7 @@ class Command(BaseCommand):
             )
             client.sync_mcp_server_tools(server_id, tool_names)
         print(f"  Synced {len(tool_names)} MCP tool(s) in Cognitive.")
+        return server_id
 
     def handle(self, project_path: Path | None, **options: Any) -> int:  # noqa: C901
         assert project_path is not None, "project_path is required"
@@ -867,7 +870,7 @@ class Command(BaseCommand):
         # -- Publish to Cognitive --
         print("\nPublishing updated MCP server/tools to Cognitive...")
         try:
-            self._publish_update(
+            server_id = self._publish_update(
                 server_name=server_name,
                 server_description=server_description,
                 server_url=server_url,
@@ -900,6 +903,13 @@ class Command(BaseCommand):
                 entry = mcp_srv_state.pop(old_server_key, None)
                 if entry:
                     mcp_srv_state[server_name] = entry
+
+            # Keep the remote id under the current name, so migrate can still
+            # delete the server after a rename.
+            remote_servers = state.setdefault("remote", {}).setdefault("mcp_servers", {})
+            if name_changed:
+                remote_servers.pop(old_server_key, None)
+            remote_servers[server_name] = server_id
 
             state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
             print("  Updated .state.json")

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -309,6 +309,48 @@ class Command(BaseCommand):
                 continue
             self._update_mcp_tool_remote_ids(remote_ids, payload)
 
+    def _apply_mcp_deletions(
+        self,
+        *,
+        client: CogSolClient,
+        state: dict[str, Any],
+        remote_ids: dict[str, Any],
+        touched: dict[str, set[str]] | None,
+    ) -> None:
+        """Delete in Cognitive the MCP servers/tools removed from the project.
+
+        A name that a migration touched but that is no longer in the state was
+        deleted, so its remote counterpart must go too.  Tools are deleted first
+        because removing a server cascades to them in the API.
+        """
+        if touched is None:
+            return
+
+        for entity, delete in (
+            ("mcp_tools", client.delete_mcp_tool),
+            ("mcp_servers", client.delete_mcp_server),
+        ):
+            surviving = state.get(entity, {}) or {}
+            removed = [name for name in sorted(touched.get(entity, set())) if name not in surviving]
+            for name in removed:
+                remote_id = (remote_ids.get(entity, {}) or {}).get(name)
+                if isinstance(remote_id, str) and remote_id.isdigit():
+                    remote_id = int(remote_id)
+                if not isinstance(remote_id, int):
+                    print(
+                        f"  Warning: no remote id known for deleted {entity[:-1]} "
+                        f"'{name}'; skipping API deletion."
+                    )
+                    continue
+                label = entity.replace("_", " ")[:-1]
+                try:
+                    delete(remote_id)
+                    print(f"  Deleted {label} '{name}' in Cognitive (id={remote_id}).")
+                except CogSolAPIError as exc:
+                    # A tool may already be gone: deleting its server cascades.
+                    print(f"  Warning: could not delete {label} '{name}' (id={remote_id}): {exc}")
+                remote_ids.get(entity, {}).pop(name, None)
+
     def _touched_entities(self, operations: list[Any]) -> dict[str, set[str]]:
         touched: dict[str, set[str]] = {}
         for op in operations:
@@ -670,10 +712,20 @@ class Command(BaseCommand):
                     if explicit_name:
                         new_remote["retrieval_tools"][explicit_name] = new_id
 
+            # MCP creations/updates are published by addmcptools/editmcptools,
+            # which need an interactive OAuth flow.  Deletions, on the other
+            # hand, are applied here so removing a server is a normal migration.
+            self._apply_mcp_deletions(
+                client=client,
+                state=state,
+                remote_ids=new_remote,
+                touched=touched,
+            )
+
             if touched is None or touched.get("mcp_servers") or touched.get("mcp_tools"):
                 print(
-                    "  MCP server/tool migration operations are skipped in 'migrate'. "
-                    "Use 'addmcptools' to publish MCP catalog to Cognitive."
+                    "  MCP server/tool creations and updates are published by "
+                    "'addmcptools'/'editmcptools'; only deletions are applied here."
                 )
 
             # Migrate only needs MCP tool ids for assistant associations.

--- a/cogsol/management/commands/startproject.py
+++ b/cogsol/management/commands/startproject.py
@@ -31,11 +31,11 @@ from cogsol.core.management import execute_from_command_line
 
 def main():
     project_path = Path(__file__).resolve().parent
-    execute_from_command_line(sys.argv, project_path=project_path)
+    return execute_from_command_line(sys.argv, project_path=project_path)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())
 """
 
 SETTINGS_PY = """\

--- a/tests/test_addmcptools.py
+++ b/tests/test_addmcptools.py
@@ -1,9 +1,58 @@
 """Tests for the addmcptools management command."""
 
 import ast
+import json
 
 from cogsol.core.api import CogSolAPIError
 from cogsol.management.commands import addmcptools
+
+
+class TestStoreServerRemoteId:
+    """The published server id must land in .state.json so migrate can delete it."""
+
+    def _state_file(self, tmp_path, payload):
+        state_path = tmp_path / "agents" / "migrations" / ".state.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+        return state_path
+
+    def test_stores_the_id_without_touching_the_rest(self, tmp_path):
+        state_path = self._state_file(
+            tmp_path,
+            {
+                "state": {"mcp_servers": {"srv": {"fields": {"name": "srv"}}}},
+                "remote": {"agents": {"MyAgent": 265}, "mcp_servers": {}},
+            },
+        )
+
+        addmcptools._store_server_remote_id(tmp_path, "agents", "srv", 186)
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert state["remote"]["mcp_servers"] == {"srv": 186}
+        assert state["remote"]["agents"] == {"MyAgent": 265}
+        assert state["state"]["mcp_servers"]["srv"]["fields"]["name"] == "srv"
+
+    def test_overwrites_the_id_when_the_server_is_republished(self, tmp_path):
+        state_path = self._state_file(tmp_path, {"remote": {"mcp_servers": {"srv": 1}}})
+
+        addmcptools._store_server_remote_id(tmp_path, "agents", "srv", 186)
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert state["remote"]["mcp_servers"]["srv"] == 186
+
+    def test_missing_state_file_is_a_no_op(self, tmp_path):
+        addmcptools._store_server_remote_id(tmp_path, "agents", "srv", 186)
+
+        assert not (tmp_path / "agents" / "migrations" / ".state.json").exists()
+
+    def test_unparsable_state_file_is_left_alone(self, tmp_path):
+        state_path = tmp_path / "agents" / "migrations" / ".state.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text("{not json", encoding="utf-8")
+
+        addmcptools._store_server_remote_id(tmp_path, "agents", "srv", 186)
+
+        assert state_path.read_text(encoding="utf-8") == "{not json"
 
 
 class TestAddMCPToolsCodegen:
@@ -83,6 +132,62 @@ class TestAddMCPToolsCodegen:
         )
         assert "name = 'tool \"one\"'" in tools_source
         assert 'description = \'desc with "quotes" and triple """ markers\'' in tools_source
+
+    def test_handle_records_the_published_server_id(self, monkeypatch, tmp_path):
+        """End-to-end: the id printed by the API must survive in .state.json."""
+
+        class FakeMCPClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def initialize(self):
+                return True
+
+            def list_tools(self):
+                return [{"name": "ping", "description": "Ping."}]
+
+            def disconnect(self):
+                return None
+
+        class FakeCogSolClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def list_mcp_servers(self):
+                return []
+
+            def upsert_mcp_server(self, *, remote_id, payload):
+                return 186
+
+            def sync_mcp_server_tools(self, server_id, selected_tools):
+                return {"results": [{"id": 1, "name": n} for n in selected_tools]}
+
+        answers = {
+            "Server name": "atlassian 5",
+            "Description": "Atlassian.",
+            "Server URL (e.g. https://mcp.example.com/mcp)": "https://example.com/mcp",
+            "Select auth type": "1",  # none
+            "Selection": "all",
+        }
+
+        monkeypatch.setattr(addmcptools, "MCPClient", FakeMCPClient)
+        monkeypatch.setattr(addmcptools, "CogSolClient", FakeCogSolClient)
+        monkeypatch.setattr(addmcptools, "_ask", lambda p, default="": answers.get(p, default))
+        monkeypatch.setenv("COGSOL_API_BASE", "https://api.example.test")
+        monkeypatch.setenv("COGSOL_API_KEY", "test-api-key")
+        monkeypatch.setenv("COGSOL_AUTH_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("COGSOL_AUTH_SECRET", "test-client-secret")
+
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        state_path = tmp_path / "agents" / "migrations" / ".state.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(json.dumps({"state": {}, "remote": {}}), encoding="utf-8")
+
+        result = addmcptools.Command().handle(project_path=tmp_path, app="agents")
+
+        assert result == 0
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert state["remote"]["mcp_servers"] == {"atlassian 5": 186}
 
 
 class TestAddMCPToolsOAuthAssisted:
@@ -317,13 +422,18 @@ class TestAddMCPToolsOAuthAssisted:
                 assert server_id == 173
                 return {"success": True}
 
-            def get_mcp_server(self, server_id):
-                calls.append("get_server")
+            def list_mcp_server_tools(self, server_id):
+                calls.append("list_tools")
                 assert server_id == 173
                 self.status_calls += 1
+                # The API has no oauth_status field: it answers 511 while the
+                # server still needs the user to authorize.
                 if self.status_calls == 1:
-                    return {"oauth_status": "disconnected"}
-                return {"oauth_status": "connected"}
+                    raise CogSolAPIError(
+                        '511 Network Authentication Required: {"mcp_oauth_required":true,'
+                        '"server_id":173,"server_name":"atlassian mcp server"}'
+                    )
+                return {"tools": [{"name": "ATLASSIANUSERINFO"}]}
 
             def get_mcp_oauth_authorization_url(self, server_id):
                 calls.append("authorize_url")
@@ -387,14 +497,13 @@ class TestAddMCPToolsOAuthAssisted:
                 assert server_id == 176
                 return {"success": True}
 
-            def get_mcp_server(self, server_id):
-                calls.append("get_server")
+            def list_mcp_server_tools(self, server_id):
+                calls.append("list_tools")
                 assert server_id == 176
                 self.status_calls += 1
-                # First check says connected; recovery path should still reauthorize after sync failure.
-                if self.status_calls == 1:
-                    return {"oauth_status": "connected"}
-                return {"oauth_status": "connected"}
+                # Already authorized; the recovery path should still reauthorize
+                # after the sync failure.
+                return {"tools": [{"name": "ATLASSIANUSERINFO"}]}
 
             def get_mcp_oauth_authorization_url(self, server_id):
                 calls.append("authorize_url")
@@ -459,9 +568,9 @@ class TestAddMCPToolsOAuthAssisted:
                 assert server_id == 176
                 return {"success": True}
 
-            def get_mcp_server(self, server_id):
+            def list_mcp_server_tools(self, server_id):
                 assert server_id == 176
-                return {"oauth_status": "connected"}
+                return {"tools": [{"name": "ATLASSIANUSERINFO"}]}
 
             def get_mcp_oauth_authorization_url(self, server_id):
                 calls.append("authorize_url")
@@ -493,6 +602,104 @@ class TestAddMCPToolsOAuthAssisted:
             pass
 
         assert "authorize_url" not in calls
+
+
+class TestAddMCPToolsRemoteServerIdentity:
+    """A remote server is identified by name — never by URL alone (CSP-1837)."""
+
+    def _client_with(self, servers):
+        class FakeCogSolClient:
+            def list_mcp_servers(self):
+                return servers
+
+        return FakeCogSolClient()
+
+    def test_same_url_different_name_is_not_adopted(self):
+        client = self._client_with(
+            [{"id": 177, "name": "Atlassian", "url": "https://mcp.atlassian.com/v1/mcp"}]
+        )
+        found = addmcptools.Command()._find_remote_server(
+            client=client,
+            server_name="mcp atlassian 3",
+            server_url="https://mcp.atlassian.com/v1/mcp",
+        )
+        # Adopting id=177 would rename it and reuse its OAuth client registration.
+        assert found is None
+
+    def test_same_name_is_adopted_even_when_url_changed(self):
+        client = self._client_with(
+            [{"id": 42, "name": "atlassian", "url": "https://mcp.atlassian.com/v1/mcp"}]
+        )
+        found = addmcptools.Command()._find_remote_server(
+            client=client,
+            server_name="Atlassian",
+            server_url="https://mcp.atlassian.com/v2/mcp",
+        )
+        assert found is not None and found["id"] == 42
+
+    def test_same_name_prefers_the_entry_matching_the_url(self):
+        client = self._client_with(
+            [
+                {"id": 1, "name": "shared", "url": "https://a.example/mcp"},
+                {"id": 2, "name": "shared", "url": "https://b.example/mcp"},
+            ]
+        )
+        found = addmcptools.Command()._find_remote_server(
+            client=client, server_name="shared", server_url="https://b.example/mcp"
+        )
+        assert found is not None and found["id"] == 2
+
+
+class TestAddMCPToolsOAuthWait:
+    """OAuth completion is detected through the tools endpoint, not oauth_status."""
+
+    def test_wait_returns_tools_once_authorization_completes(self, monkeypatch):
+        class FakeCogSolClient:
+            def __init__(self):
+                self.calls = 0
+
+            def list_mcp_server_tools(self, _server_id):
+                self.calls += 1
+                if self.calls < 3:
+                    raise CogSolAPIError(
+                        '511 Network Authentication Required: {"mcp_oauth_required":true}'
+                    )
+                return {"tools": [{"name": "ATLASSIANUSERINFO"}]}
+
+        monkeypatch.setattr(addmcptools.time, "sleep", lambda _s: None)
+        tools = addmcptools.Command()._wait_for_oauth_connected(
+            client=FakeCogSolClient(), server_id=1, timeout_seconds=30
+        )
+        assert tools == [{"name": "ATLASSIANUSERINFO"}]
+
+    def test_wait_times_out_while_authorization_stays_pending(self, monkeypatch):
+        class FakeCogSolClient:
+            def list_mcp_server_tools(self, _server_id):
+                raise CogSolAPIError(
+                    '511 Network Authentication Required: {"mcp_oauth_required":true}'
+                )
+
+        monkeypatch.setattr(addmcptools.time, "sleep", lambda _s: None)
+        result = addmcptools.Command()._wait_for_oauth_connected(
+            client=FakeCogSolClient(), server_id=1, timeout_seconds=0
+        )
+        assert result is None
+
+    def test_missing_oauth_status_field_does_not_block_detection(self, monkeypatch):
+        """A server detail payload without oauth_status must not be consulted at all."""
+
+        class FakeCogSolClient:
+            def get_mcp_server(self, _server_id):
+                raise AssertionError("oauth_status is not part of the API contract")
+
+            def list_mcp_server_tools(self, _server_id):
+                return {"tools": [{"name": "PING"}]}
+
+        monkeypatch.setattr(addmcptools.time, "sleep", lambda _s: None)
+        tools = addmcptools.Command()._wait_for_oauth_connected(
+            client=FakeCogSolClient(), server_id=1, timeout_seconds=5
+        )
+        assert tools == [{"name": "PING"}]
 
 
 class TestAddMCPToolsHeadersPayload:

--- a/tests/test_deletemcptools.py
+++ b/tests/test_deletemcptools.py
@@ -210,4 +210,6 @@ def test_delete_cleans_the_agent_that_used_the_tool(monkeypatch, tmp_path, capsy
     assert "AtlassianuserinfoMCPTool" not in agent_source
     assert "tools = []" in agent_source
     ast.parse(agent_source)
-    assert "Removed AtlassianuserinfoMCPTool from agents/miagente/agent.py" in out
+    # The path is printed with the platform separator.
+    relative_agent = Path("agents") / "miagente" / "agent.py"
+    assert f"Removed AtlassianuserinfoMCPTool from {relative_agent}" in out

--- a/tests/test_deletemcptools.py
+++ b/tests/test_deletemcptools.py
@@ -1,0 +1,213 @@
+"""Tests for deletemcptools.
+
+The command only edits the project: the deletion reaches Cognitive through
+``makemigrations`` + ``migrate``, like every other change (CSP-1837).
+"""
+
+import ast
+import json
+from pathlib import Path
+
+from cogsol.management.commands import deletemcptools
+
+ATLASSIAN_URL = "https://mcp.atlassian.com/v1/mcp"
+
+
+def _project(tmp_path: Path, server_name: str, class_name: str) -> Path:
+    agents = tmp_path / "agents"
+    (agents / "migrations").mkdir(parents=True)
+    (agents / "__init__.py").write_text("", encoding="utf-8")
+    (agents / "mcp_servers.py").write_text(
+        "from cogsol.tools import BaseMCPServer\n"
+        "\n"
+        f"class {class_name}(BaseMCPServer):\n"
+        f"    name = {server_name!r}\n"
+        f"    url = {ATLASSIAN_URL!r}\n"
+        '    auth_type = "oauth2"\n',
+        encoding="utf-8",
+    )
+    (agents / "mcp_tools.py").write_text("from cogsol.tools import BaseMCPTool\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    return tmp_path
+
+
+def _write_state(project: Path, server_name: str, tool_names: list[str]) -> Path:
+    state_path = project / "agents" / "migrations" / ".state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "state": {
+                    "mcp_servers": {server_name: {"fields": {"name": server_name}, "meta": {}}},
+                    "mcp_tools": {
+                        name: {"fields": {"name": name}, "meta": {}} for name in tool_names
+                    },
+                },
+                "remote": {
+                    "mcp_servers": {server_name: 185},
+                    "mcp_tools": dict.fromkeys(tool_names, 1169),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return state_path
+
+
+def _run(monkeypatch, project):
+    monkeypatch.setattr(deletemcptools, "_ask", lambda *_a, **_k: "1")
+    monkeypatch.setattr(deletemcptools, "_ask_yes_no", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        deletemcptools.Command, "ensure_credentials_configured", lambda _self, _p: True
+    )
+    return deletemcptools.Command().handle(project_path=project, app="agents")
+
+
+class TestDeleteIsProjectOnly:
+    def test_does_not_call_the_api(self, monkeypatch, tmp_path, capsys):
+        """The module must not even build an API client."""
+        project = _project(tmp_path, "mcp atlassian 4", "McpAtlassian4MCPServer")
+
+        result = _run(monkeypatch, project)
+        out = capsys.readouterr().out
+
+        assert result == 0
+        assert not hasattr(deletemcptools, "CogSolClient")
+        assert "Nothing was deleted in Cognitive yet" in out
+
+    def test_keeps_remote_ids_so_migrate_can_delete(self, monkeypatch, tmp_path, capsys):
+        project = _project(tmp_path, "mcp atlassian 4", "McpAtlassian4MCPServer")
+        state_path = _write_state(project, "mcp atlassian 4", ["atlassianUserInfo"])
+
+        _run(monkeypatch, project)
+        capsys.readouterr()
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        # Local definitions are gone...
+        assert state["state"]["mcp_servers"] == {}
+        # ...but the ids survive for migrate to use.
+        assert state["remote"]["mcp_servers"]["mcp atlassian 4"] == 185
+        assert state["remote"]["mcp_tools"]["atlassianUserInfo"] == 1169
+
+
+class TestRemoveToolReferences:
+    """Deleting a tool must also remove the references that would break imports."""
+
+    def test_removes_entry_and_import_from_single_line_list(self):
+        source = (
+            "from cogsol.agents import BaseAgent\n"
+            "from agents.mcp_tools import AtlassianuserinfoMCPTool\n"
+            "\n"
+            "class MyAgent(BaseAgent):\n"
+            "    tools = [AtlassianuserinfoMCPTool()]\n"
+            "    temperature = 0.3\n"
+        )
+
+        new_source, removed = deletemcptools._remove_tool_references(
+            source, {"AtlassianuserinfoMCPTool"}
+        )
+
+        assert removed == ["AtlassianuserinfoMCPTool"]
+        assert "AtlassianuserinfoMCPTool" not in new_source
+        assert "    tools = []\n" in new_source
+        assert "    temperature = 0.3\n" in new_source
+        ast.parse(new_source)
+
+    def test_keeps_the_other_tools_and_trims_the_import(self):
+        source = (
+            "from agents.mcp_tools import KeepMeMCPTool, DropMeMCPTool\n"
+            "from agents.tools import ExampleTool\n"
+            "\n"
+            "class MyAgent(BaseAgent):\n"
+            "    tools = [ExampleTool(), DropMeMCPTool(), KeepMeMCPTool()]\n"
+        )
+
+        new_source, removed = deletemcptools._remove_tool_references(source, {"DropMeMCPTool"})
+
+        assert removed == ["DropMeMCPTool"]
+        assert "from agents.mcp_tools import KeepMeMCPTool\n" in new_source
+        assert "    tools = [ExampleTool(), KeepMeMCPTool()]\n" in new_source
+        ast.parse(new_source)
+
+    def test_preserves_multiline_list_formatting(self):
+        source = (
+            "class MyAgent(BaseAgent):\n"
+            "    tools = [\n"
+            "        ExampleTool(),\n"
+            "        DropMeMCPTool(),\n"
+            "    ]\n"
+        )
+
+        new_source, _ = deletemcptools._remove_tool_references(source, {"DropMeMCPTool"})
+
+        assert new_source == (
+            "class MyAgent(BaseAgent):\n" "    tools = [\n" "        ExampleTool(),\n" "    ]\n"
+        )
+        ast.parse(new_source)
+
+    def test_handles_pretools_and_bare_class_references(self):
+        source = (
+            "class MyAgent(BaseAgent):\n"
+            "    tools = [KeepMeMCPTool()]\n"
+            "    pretools = [DropMeMCPTool]\n"
+        )
+
+        new_source, removed = deletemcptools._remove_tool_references(source, {"DropMeMCPTool"})
+
+        assert removed == ["DropMeMCPTool"]
+        assert "    pretools = []\n" in new_source
+        assert "    tools = [KeepMeMCPTool()]\n" in new_source
+
+    def test_untouched_when_nothing_matches(self):
+        source = "class MyAgent(BaseAgent):\n    tools = [ExampleTool()]\n"
+
+        new_source, removed = deletemcptools._remove_tool_references(source, {"OtherMCPTool"})
+
+        assert new_source == source
+        assert removed == []
+
+    def test_unparsable_source_is_left_alone(self):
+        source = "class MyAgent(  # broken\n"
+
+        new_source, removed = deletemcptools._remove_tool_references(source, {"AnyMCPTool"})
+
+        assert new_source == source
+        assert removed == []
+
+
+def test_delete_cleans_the_agent_that_used_the_tool(monkeypatch, tmp_path, capsys):
+    """End-to-end: after deleting, the project must still be importable."""
+    project = _project(tmp_path, "mcp atlassian 4", "McpAtlassian4MCPServer")
+    agents = project / "agents"
+    (agents / "mcp_tools.py").write_text(
+        "from cogsol.tools import BaseMCPTool\n"
+        "\n"
+        "from agents.mcp_servers import McpAtlassian4MCPServer\n"
+        "\n"
+        "\n"
+        "class AtlassianuserinfoMCPTool(BaseMCPTool):\n"
+        "    name = 'atlassianUserInfo'\n"
+        "    server = McpAtlassian4MCPServer\n",
+        encoding="utf-8",
+    )
+    agent_dir = agents / "miagente"
+    agent_dir.mkdir()
+    (agent_dir / "__init__.py").write_text("", encoding="utf-8")
+    (agent_dir / "agent.py").write_text(
+        "from cogsol.agents import BaseAgent\n"
+        "from agents.mcp_tools import AtlassianuserinfoMCPTool\n"
+        "\n"
+        "\n"
+        "class MiagenteAgent(BaseAgent):\n"
+        "    tools = [AtlassianuserinfoMCPTool()]\n",
+        encoding="utf-8",
+    )
+
+    result = _run(monkeypatch, project)
+    out = capsys.readouterr().out
+
+    assert result == 0
+    agent_source = (agent_dir / "agent.py").read_text(encoding="utf-8")
+    assert "AtlassianuserinfoMCPTool" not in agent_source
+    assert "tools = []" in agent_source
+    ast.parse(agent_source)
+    assert "Removed AtlassianuserinfoMCPTool from agents/miagente/agent.py" in out

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -1,0 +1,72 @@
+"""Tests for turning HTTP error bodies into one-line terminal messages."""
+
+from cogsol.core.http_errors import MAX_DETAIL_LENGTH, summarize_http_error
+
+DJANGO_DEBUG_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>IntegrityError
+          at /cognitive/assistants/</title>
+</head>
+<body>
+  <pre class="exception_value">null value in column &quot;async_available&quot; of relation
+&quot;assistants&quot; violates not-null constraint</pre>
+  <div id="traceback">... hundreds of KB of frames ...</div>
+</body>
+</html>
+"""
+
+
+class TestDjangoDebugPages:
+    def test_extracts_exception_type_path_and_message(self):
+        summary = summarize_http_error(DJANGO_DEBUG_PAGE)
+
+        assert summary == (
+            "IntegrityError at /cognitive/assistants/: "
+            'null value in column "async_available" of relation '
+            '"assistants" violates not-null constraint'
+        )
+
+    def test_does_not_leak_markup_or_traceback(self):
+        summary = summarize_http_error(DJANGO_DEBUG_PAGE)
+
+        assert "<pre" not in summary
+        assert "traceback" not in summary.lower()
+        assert "&quot;" not in summary
+
+    def test_long_summaries_are_truncated(self):
+        page = DJANGO_DEBUG_PAGE.replace(
+            "violates not-null constraint",
+            "violates not-null constraint DETAIL: Failing row contains " + "x" * 500,
+        )
+
+        summary = summarize_http_error(page)
+
+        assert len(summary) <= MAX_DETAIL_LENGTH
+        assert summary.endswith("...")
+
+
+class TestOtherErrorBodies:
+    def test_cloudflare_page_falls_back_to_the_title(self):
+        page = (
+            "<!DOCTYPE html><html><head><title>Access denied | Cloudflare</title></head>"
+            "<body><h1>Error 1010</h1></body></html>"
+        )
+
+        summary = summarize_http_error(page)
+
+        assert summary == "HTML error page returned (Access denied | Cloudflare)"
+
+    def test_html_without_title_or_heading(self):
+        summary = summarize_http_error("<html><body><p>nope</p></body></html>")
+
+        assert summary == "HTML error page returned by remote server"
+
+    def test_json_bodies_pass_through(self):
+        summary = summarize_http_error('{"error":"Invalid API key"}')
+
+        assert summary == '{"error":"Invalid API key"}'
+
+    def test_empty_body(self):
+        assert summarize_http_error("") == ""
+        assert summarize_http_error("   ") == ""

--- a/tests/test_loader_missing_deps.py
+++ b/tests/test_loader_missing_deps.py
@@ -79,3 +79,45 @@ def test_missing_project_module_still_raises():
 
     with pytest.raises(RuntimeError, match="agents.tools"):
         collect_definitions(project, "agents")
+
+
+def test_app_module_imported_without_its_app_raises():
+    """`from mcp_tools import X` (instead of `agents.mcp_tools`) must not be stubbed.
+
+    Stubbing it produced a placeholder object that was written verbatim into the
+    generated migration, yielding a file with a SyntaxError.
+    """
+    project = _make_project("from cogsol.tools import BaseTool\n")
+    agents = project / "agents"
+    (agents / "mcp_tools.py").write_text(
+        "from cogsol.tools import BaseMCPTool\n"
+        "\n"
+        "class SampleMCPTool(BaseMCPTool):\n"
+        "    name = 'sample'\n",
+        encoding="utf-8",
+    )
+    agent_dir = agents / "myagent"
+    agent_dir.mkdir()
+    (agent_dir / "__init__.py").write_text("", encoding="utf-8")
+    (agent_dir / "agent.py").write_text(
+        "from cogsol.agents import BaseAgent\n"
+        "from mcp_tools import SampleMCPTool\n"  # missing the `agents.` prefix
+        "\n"
+        "class MyAgent(BaseAgent):\n"
+        "    tools = [SampleMCPTool()]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="mcp_tools"):
+        collect_definitions(project, "agents")
+
+
+def test_stub_values_are_never_serialized_into_migrations():
+    """A leaked stub must fail loudly rather than reach a migration file."""
+    from cogsol.core.loader import _StubValue, serialize_value
+
+    with pytest.raises(RuntimeError, match="could not be imported"):
+        serialize_value(_StubValue("some_pkg.Thing"))
+
+    with pytest.raises(RuntimeError, match="could not be imported"):
+        serialize_value([_StubValue("some_pkg.Thing")])

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,6 +1,11 @@
 """Tests for MCP client error formatting."""
 
-from cogsol.core.mcp import MCPClient
+import json
+from urllib import request
+
+import pytest
+
+from cogsol.core.mcp import DEFAULT_USER_AGENT, MCPClient, MCPClientError
 
 
 class TestMCPClientErrorSummary:
@@ -26,3 +31,94 @@ class TestMCPClientErrorSummary:
 
         assert len(summary) <= 240
         assert summary.endswith("...")
+
+
+class TestMCPClientUserAgent:
+    """A default User-Agent is required: CDNs reject the urllib signature with 403."""
+
+    def _capture_request(self, monkeypatch):
+        captured = {}
+
+        class FakeResponse:
+            headers = {"Content-Type": "application/json"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps({"result": {"tools": []}}).encode("utf-8")
+
+        def fake_urlopen(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            return FakeResponse()
+
+        monkeypatch.setattr(request, "urlopen", fake_urlopen)
+        return captured
+
+    def test_sends_default_user_agent(self, monkeypatch):
+        captured = self._capture_request(monkeypatch)
+
+        MCPClient("https://mcp.example.com/mcp").initialize()
+
+        # urllib capitalizes header names on the Request object.
+        assert captured["headers"]["User-agent"] == DEFAULT_USER_AGENT
+
+    def test_caller_supplied_user_agent_wins(self, monkeypatch):
+        captured = self._capture_request(monkeypatch)
+
+        MCPClient(
+            "https://mcp.example.com/mcp", headers={"User-Agent": "custom-agent/9"}
+        ).initialize()
+
+        assert captured["headers"]["User-agent"] == "custom-agent/9"
+
+
+class TestMCPClientFailureMessages:
+    """Handshake failures are explained, not dumped as raw payloads."""
+
+    @pytest.mark.parametrize("auth_type", ["headers", "oauth2"])
+    def test_403_is_explained_without_raw_payload(self, auth_type):
+        client = MCPClient("https://mcp.example.com/mcp", auth_type=auth_type)
+        exc = MCPClientError(
+            'HTTP 403 Forbidden: {"type":"https://developers.cloudflare.com/.../error-1010/",'
+            '"title":"Error 1010: Access denied","status":403}'
+        )
+
+        message = client._describe_initialize_failure(exc)
+
+        assert "CDN or WAF" in message
+        assert "cloudflare.com" not in message
+        assert ("not fatal" in message) is (auth_type == "oauth2")
+
+    def test_401_on_oauth_server_is_expected_not_an_error(self):
+        client = MCPClient("https://mcp.example.com/mcp", auth_type="oauth2")
+
+        message = client._describe_initialize_failure(MCPClientError("HTTP 401 Unauthorized"))
+
+        assert "expected" in message
+
+    def test_401_on_header_server_points_at_credentials(self):
+        client = MCPClient("https://mcp.example.com/mcp", auth_type="headers")
+
+        message = client._describe_initialize_failure(MCPClientError("HTTP 401 Unauthorized"))
+
+        assert "header values" in message
+
+    def test_unknown_failures_keep_the_original_detail(self):
+        client = MCPClient("https://mcp.example.com/mcp")
+
+        message = client._describe_initialize_failure(MCPClientError("HTTP 500 Server Error"))
+
+        assert "HTTP 500 Server Error" in message
+
+    def test_connection_errors_suggest_checking_the_url(self):
+        client = MCPClient("https://mcp.example.com/mcp")
+
+        message = client._describe_initialize_failure(
+            MCPClientError("Connection error: [Errno -2] Name or service not known")
+        )
+
+        assert "Check the URL" in message

--- a/tests/test_migrate_tools.py
+++ b/tests/test_migrate_tools.py
@@ -2,6 +2,8 @@
 Tests for tool code transformation during migrations.
 """
 
+from __future__ import annotations
+
 import ast
 from pathlib import Path
 

--- a/tests/test_migrate_tools.py
+++ b/tests/test_migrate_tools.py
@@ -490,6 +490,98 @@ class TestContentMigrationFilters:
         assert calls[-1][1]["filters"] == [20]
 
 
+class TestApplyMCPDeletions:
+    """MCP removals reach Cognitive through migrate, using the stored ids."""
+
+    class FakeClient:
+        def __init__(self, failing: set[int] | None = None):
+            self.deleted: list[tuple[str, int]] = []
+            self.failing = failing or set()
+
+        def delete_mcp_server(self, server_id):
+            if server_id in self.failing:
+                raise CogSolAPIError("404 Not Found")
+            self.deleted.append(("server", server_id))
+
+        def delete_mcp_tool(self, tool_id):
+            if tool_id in self.failing:
+                raise CogSolAPIError("404 Not Found")
+            self.deleted.append(("tool", tool_id))
+
+    def _state(self):
+        return {"mcp_servers": {}, "mcp_tools": {}}
+
+    def test_deletes_tools_before_servers_using_stored_ids(self) -> None:
+        client = self.FakeClient()
+        remote_ids = {"mcp_servers": {"srv": 185}, "mcp_tools": {"toolA": 1169}}
+
+        Command()._apply_mcp_deletions(
+            client=client,
+            state=self._state(),
+            remote_ids=remote_ids,
+            touched={"mcp_servers": {"srv"}, "mcp_tools": {"toolA"}},
+        )
+
+        assert client.deleted == [("tool", 1169), ("server", 185)]
+        # Ids are dropped once applied.
+        assert remote_ids["mcp_servers"] == {}
+        assert remote_ids["mcp_tools"] == {}
+
+    def test_keeps_entities_that_still_exist(self) -> None:
+        client = self.FakeClient()
+        state = {"mcp_servers": {"srv": {"fields": {}}}, "mcp_tools": {}}
+
+        Command()._apply_mcp_deletions(
+            client=client,
+            state=state,
+            remote_ids={"mcp_servers": {"srv": 185}, "mcp_tools": {}},
+            touched={"mcp_servers": {"srv"}},
+        )
+
+        assert client.deleted == []
+
+    def test_warns_when_no_remote_id_is_known(self, capsys) -> None:
+        client = self.FakeClient()
+
+        Command()._apply_mcp_deletions(
+            client=client,
+            state=self._state(),
+            remote_ids={"mcp_servers": {}, "mcp_tools": {}},
+            touched={"mcp_servers": {"never-published"}},
+        )
+        out = capsys.readouterr().out
+
+        assert client.deleted == []
+        assert "no remote id known" in out
+
+    def test_api_failure_is_reported_without_aborting(self, capsys) -> None:
+        """A tool already removed by its server's cascade must not stop the run."""
+        client = self.FakeClient(failing={1169})
+
+        Command()._apply_mcp_deletions(
+            client=client,
+            state=self._state(),
+            remote_ids={"mcp_servers": {"srv": 185}, "mcp_tools": {"toolA": 1169}},
+            touched={"mcp_servers": {"srv"}, "mcp_tools": {"toolA"}},
+        )
+        out = capsys.readouterr().out
+
+        assert client.deleted == [("server", 185)]
+        assert "could not delete" in out
+
+    def test_full_sync_without_pending_operations_deletes_nothing(self) -> None:
+        client = self.FakeClient()
+
+        Command()._apply_mcp_deletions(
+            client=client,
+            state=self._state(),
+            remote_ids={"mcp_servers": {"srv": 185}, "mcp_tools": {}},
+            touched=None,
+        )
+
+        assert client.deleted == []
+
+
 class TestRollbackDeleteDispatch:
     def test_delete_created_entry_supports_mcp_tool(self) -> None:
         class FakeClient:


### PR DESCRIPTION
# Summary

Completes the MCP server lifecycle: OAuth authorization is verified before syncing tools, remote servers are matched by name, and removals now reach Cognitive through `migrate`.

## Changes

### OAuth
- `_is_authorized` checks a server's OAuth status before syncing its tools.
- `_wait_for_oauth_connected` reports why authorization failed instead of just timing out.

### Server identity
- `_find_remote_server` adopts a remote server only when the name matches, so a shared URL no longer overwrites a different server.
- `_publish_to_cognitive` / `_publish_update` return the remote server id, which is stored in `.state.json` so `migrate` can delete the server later.

### Deletions
- New `deletemcptools` command: removes the server, its tools and their references from the project (source files, `.env`, `.state.json`) without calling the API. The removal is published by `makemigrations` + `migrate`, like any other change.
- `_apply_mcp_deletions` in `migrate` deletes MCP tools before servers and tolerates already-cascaded tools, so a failed tool deletion doesn't abort the run.

### Error reporting
- New `cogsol/core/http_errors.py`: HTML error pages from remote services are summarized into a single readable line instead of being printed verbatim.

### Tests
- New suites for `deletemcptools`, HTTP error summarizing, and loading definitions whose tool code imports packages that only exist in the Cognitive runtime.
- Added cases for server identity, OAuth wait logic, MCP client behavior and MCP deletions during migration.
