### PR TITLE
feat: Add missing agent configuration and fix fields that never reached Cognitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BaseAgent.attachments`: agents can now declare which file types the chat accepts and which ones reach the model, through the `attachment` specs (`Pdf`, `Image`, `Word`, `Excel`, `Text`, `Markdown`, `Latex`, `Binary` and `Custom`). Each spec takes `accepted` and `send_to_model`, and `Pdf` takes `mode="image"|"text"`. Mapped to the Cognitive `attachment_config` field. Declaring `attachments = []` accepts no attachments.
+- `BaseAgent.reasoning_effort` and `BaseAgent.reasoning_summary` to configure reasoning beyond the on/off flag.
+- `BaseAgent.websearch_mode`, `BaseAgent.websearch_domains` and `BaseAgent.websearch_location` to configure web search beyond the on/off flag.
+- `BaseAgent.asynchronous`, mapped to the Cognitive `async_available` field.
+- `BaseAgent.append_to_user_message`, mapped to the Cognitive `add_to_user_message` field.
+- `optimizations.SkipAllContent()` and `optimizations.NoOptimization()`, completing the token optimization strategies the Generator recognizes.
+- `importagent` now imports every configuration above, including reconstructing `attachments` from the remote `attachment_config`, and declares `streaming`/`realtime` in the generated agent instead of only in the migration state.
+- Choice, domain and attachment values are validated locally during `migrate`, with the list of valid values in the error message. Cognitive does not run model validation on these fields, so an invalid configuration used to be persisted silently and never work.
+
+### Changed
+- Optional agent configuration is only sent to Cognitive when the agent class declares it. Anything left to the portal now survives a `migrate` instead of being reset to a framework default. The attributes already sent in previous versions keep being sent unconditionally.
+- `BaseAgent.user_interactions_window`, `BaseAgent.token_optimization` and `BaseAgent.self_improvement_mode` are now applied. All three were documented but never reached Cognitive, so agents declaring them will see their behaviour change on the next `migrate`: history sent to the model is capped by `user_interactions_window`, past retrieval results are trimmed per `token_optimization`, and `self_improvement_mode` enables matrix mode (`matrix_mode_available`).
+
+### Fixed
+- `BaseAgent.reasoning` and `BaseAgent.websearch` had no effect: `migrate` sent them as `reasoning_available` and `websearch_available`, fields that do not exist in Cognitive, so they were silently discarded. They are now sent as `reasoning_enabled` and `web_search_enabled`. **Agents that already declare these flags will actually enable reasoning or web search on the next `migrate`, which changes the cost per message.** `importagent` read the same non-existent fields and never imported them.
+- `migrate` no longer wipes `add_to_user_message` and `strategy_to_optimize_tokens`, which were hardcoded to `null` on every run and overwrote whatever was configured in the portal.
+- `matrix_mode_available` is no longer derived from `realtime`. They are separate Cognitive features: matrix mode requires FAQ support and is rejected in production, so a `realtime` agent without FAQs failed to migrate. It is now driven by `self_improvement_mode`, and agents relying on the old behaviour stop having matrix mode enabled on the next `migrate`.
+- `importagent` no longer writes migration state for attributes the generated agent does not declare, which made the first `makemigrations` after an import report changes that were not there.
+
 ---
 
 ## [0.3.0] - 2026-07-15

--- a/cogsol/agents/__init__.py
+++ b/cogsol/agents/__init__.py
@@ -16,6 +16,102 @@ from cogsol.core.api import CogSolAPIError, CogSolClient
 from cogsol.core.constants import get_cognitive_api_base_url
 from cogsol.core.env import load_dotenv
 
+# Values Cognitive accepts for each choice field.
+REASONING_EFFORTS = ("low", "medium", "high", "xhigh", "none")
+REASONING_SUMMARIES = ("auto", "concise", "detailed", "none")
+WEBSEARCH_MODES = ("agentic", "deep_research")
+WEBSEARCH_LOCATION_KEYS = ("country", "city", "region", "timezone")
+PDF_MODES = ("image", "text")
+
+PDF_CONTENT_TYPE = "application/pdf"
+
+ATTACHMENT_CONTENT_TYPES = (
+    PDF_CONTENT_TYPE,
+    "image/png",
+    "image/jpeg",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+    "text/x-tex",
+    "application/x-tex",
+    "application/x-latex",
+    "text/plain",
+    "text/markdown",
+    "text/x-markdown",
+    "application/octet-stream",
+)
+
+
+@dataclass(frozen=True)
+class _AttachmentSpec:
+    # content_types is a field, not a ClassVar, so the migration diff can tell two
+    # specs apart when their flags are identical.
+    content_types: tuple[str, ...] = ()
+    accepted: bool = True
+    send_to_model: bool = False
+
+
+class attachment:
+    """Attachment types an agent can accept, grouped by format."""
+
+    @dataclass(frozen=True)
+    class Pdf(_AttachmentSpec):
+        """PDFs. ``mode='image'`` sends the raw file, ``'text'`` sends extracted text."""
+
+        content_types: tuple[str, ...] = (PDF_CONTENT_TYPE,)
+        mode: str = "image"
+
+    @dataclass(frozen=True)
+    class Image(_AttachmentSpec):
+        """PNG and JPEG images, always delivered as raw files."""
+
+        content_types: tuple[str, ...] = ("image/png", "image/jpeg")
+
+    @dataclass(frozen=True)
+    class Word(_AttachmentSpec):
+        """Word documents (.docx)."""
+
+        content_types: tuple[str, ...] = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+    @dataclass(frozen=True)
+    class Excel(_AttachmentSpec):
+        """Excel spreadsheets (.xlsx, .xls)."""
+
+        content_types: tuple[str, ...] = (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+        )
+
+    @dataclass(frozen=True)
+    class Text(_AttachmentSpec):
+        """Plain text files."""
+
+        content_types: tuple[str, ...] = ("text/plain",)
+
+    @dataclass(frozen=True)
+    class Markdown(_AttachmentSpec):
+        """Markdown files."""
+
+        content_types: tuple[str, ...] = ("text/markdown", "text/x-markdown")
+
+    @dataclass(frozen=True)
+    class Latex(_AttachmentSpec):
+        """LaTeX sources."""
+
+        content_types: tuple[str, ...] = ("text/x-tex", "application/x-tex", "application/x-latex")
+
+    @dataclass(frozen=True)
+    class Binary(_AttachmentSpec):
+        """Files without a recognized content type."""
+
+        content_types: tuple[str, ...] = ("application/octet-stream",)
+
+    @dataclass(frozen=True)
+    class Custom(_AttachmentSpec):
+        """Content types Cognitive accepts but this version does not name."""
+
 
 class BaseAgent:
     """
@@ -36,12 +132,21 @@ class BaseAgent:
     user_message_length: int | None = None
     consecutive_tool_calls_limit: int | None = None
     user_interactions_window: int | None = None
+    append_to_user_message: str | None = None
     token_optimization: Any = None
     streaming: bool = False
+    # Cognitive "matrix mode": requires FAQs and is rejected in production.
     self_improvement_mode: bool = False
     realtime: bool = False
+    asynchronous: bool = False
     reasoning: bool = False
+    reasoning_effort: str | None = None
+    reasoning_summary: str | None = None
     websearch: bool = False
+    websearch_mode: str | None = None
+    websearch_domains: list[str] | None = None
+    websearch_location: dict[str, str] | None = None
+    attachments: list[Any] = []
     lessons: list[Any] = []
     faqs: list[Any] = []
     fixed_responses: list[Any] = []
@@ -245,5 +350,25 @@ class optimizations:
         def __init__(self) -> None:
             super().__init__("description_only")
 
+    class SkipAllContent(_ConfigBase):
+        def __init__(self) -> None:
+            super().__init__("skip_all_content")
 
-__all__ = ["BaseAgent", "genconfigs", "optimizations"]
+    class NoOptimization(_ConfigBase):
+        def __init__(self) -> None:
+            super().__init__("no_optimization")
+
+
+__all__ = [
+    "ATTACHMENT_CONTENT_TYPES",
+    "PDF_CONTENT_TYPE",
+    "PDF_MODES",
+    "REASONING_EFFORTS",
+    "REASONING_SUMMARIES",
+    "WEBSEARCH_LOCATION_KEYS",
+    "WEBSEARCH_MODES",
+    "BaseAgent",
+    "attachment",
+    "genconfigs",
+    "optimizations",
+]

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -36,6 +36,94 @@ def _safe_class_name(name: str, fallback: str) -> str:
     return _camelize(cleaned, "")
 
 
+_DOCX_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_XLSX_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+# Matched in this order when rebuilding an agent from a remote attachment_config.
+_NAMED_ATTACHMENT_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Pdf", ("application/pdf",)),
+    ("Image", ("image/png", "image/jpeg")),
+    ("Word", (_DOCX_TYPE,)),
+    ("Excel", (_XLSX_TYPE, "application/vnd.ms-excel")),
+    ("Text", ("text/plain",)),
+    ("Markdown", ("text/markdown", "text/x-markdown")),
+    ("Latex", ("text/x-tex", "application/x-tex", "application/x-latex")),
+    ("Binary", ("application/octet-stream",)),
+)
+
+_TOKEN_OPTIMIZATIONS = {
+    "description_only": "DescriptionOnly",
+    "skip_all_content": "SkipAllContent",
+}
+
+
+def _attachment_specs_from_config(
+    config: Any,
+) -> list[tuple[str, dict[str, Any], tuple[str, ...]]]:
+    """Rebuild ``(class_name, kwargs, content_types)`` specs from a remote attachment_config."""
+    if not isinstance(config, dict) or not config:
+        return []
+
+    buckets: dict[tuple[bool, bool, Any], list[str]] = {}
+    for content_type, cfg in config.items():
+        if not isinstance(cfg, dict):
+            continue
+        key = (bool(cfg.get("accepted")), bool(cfg.get("send_to_model")), cfg.get("pdf_mode"))
+        buckets.setdefault(key, []).append(str(content_type))
+
+    specs: list[tuple[str, dict[str, Any], tuple[str, ...]]] = []
+    ordered = sorted(buckets.items(), key=lambda kv: (kv[0][0], kv[0][1], kv[0][2] or ""))
+    for (accepted, send_to_model, pdf_mode), content_types in ordered:
+        remaining = sorted(content_types)
+        for class_name, group in _NAMED_ATTACHMENT_GROUPS:
+            if not all(ct in remaining for ct in group):
+                continue
+            kwargs: dict[str, Any] = {"accepted": accepted, "send_to_model": send_to_model}
+            if class_name == "Pdf":
+                kwargs["mode"] = pdf_mode or "image"
+            specs.append((class_name, kwargs, group))
+            for ct in group:
+                remaining.remove(ct)
+        if remaining:
+            leftover = tuple(remaining)
+            kwargs = {
+                "content_types": leftover,
+                "accepted": accepted,
+                "send_to_model": send_to_model,
+            }
+            specs.append(("Custom", kwargs, leftover))
+    return specs
+
+
+def _attachment_source(specs: list[tuple[str, dict[str, Any], tuple[str, ...]]]) -> str:
+    """Render attachment specs as the source of an ``attachments`` class attribute."""
+    if not specs:
+        return ""
+    lines = ["    attachments = ["]
+    for class_name, kwargs, _ in specs:
+        args = ", ".join(f"{key}={value!r}" for key, value in kwargs.items())
+        lines.append(f"        attachment.{class_name}({args}),")
+    lines.append("    ]")
+    return "\n".join(lines) + "\n"
+
+
+def _attachment_state(
+    specs: list[tuple[str, dict[str, Any], tuple[str, ...]]],
+) -> list[dict[str, Any]]:
+    """Render attachment specs the way ``serialize_value`` renders the generated source."""
+    state: list[dict[str, Any]] = []
+    for _, kwargs, content_types in specs:
+        entry: dict[str, Any] = {
+            "accepted": kwargs["accepted"],
+            "content_types": list(content_types),
+            "send_to_model": kwargs["send_to_model"],
+        }
+        if "mode" in kwargs:
+            entry["mode"] = kwargs["mode"]
+        state.append(entry)
+    return state
+
+
 def _write_file(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -525,15 +613,68 @@ class Command(BaseCommand):
                 meta_lines.append(f"        {meta_attr} = {color_value!r}")
         meta_block = "\n".join(meta_lines)
 
-        _reasoning = bool(assistant.get("reasoning_available", False))
-        _websearch = bool(assistant.get("websearch_available", False))
-        _extra_fields = ""
-        if _reasoning:
-            _extra_fields += "    reasoning = True\n"
-        if _websearch:
-            _extra_fields += "    websearch = True\n"
+        attachment_specs = _attachment_specs_from_config(assistant.get("attachment_config"))
+        token_strategy = _TOKEN_OPTIMIZATIONS.get(
+            str(assistant.get("strategy_to_optimize_tokens") or "")
+        )
 
-        agent_py = f"""from cogsol.agents import BaseAgent, genconfigs
+        # Emitted only when the assistant uses them; declared_extras mirrors exactly
+        # what the generated class declares, so the migration state matches it.
+        extra_lines: list[str] = []
+        declared_extras: dict[str, Any] = {}
+
+        def _declare(attr: str, state_value: Any, source_value: str | None = None) -> None:
+            extra_lines.append(f"    {attr} = {source_value or repr(state_value)}")
+            declared_extras[attr] = state_value
+
+        if assistant.get("streaming_available"):
+            _declare("streaming", True)
+        if assistant.get("realtime_available"):
+            _declare("realtime", True)
+        if assistant.get("async_available"):
+            _declare("asynchronous", True)
+        if assistant.get("matrix_mode_available"):
+            _declare("self_improvement_mode", True)
+        if assistant.get("reasoning_enabled"):
+            _declare("reasoning", True)
+        if assistant.get("reasoning_effort"):
+            _declare("reasoning_effort", assistant.get("reasoning_effort"))
+        if assistant.get("reasoning_summary"):
+            _declare("reasoning_summary", assistant.get("reasoning_summary"))
+        if assistant.get("web_search_enabled"):
+            _declare("websearch", True)
+        if assistant.get("web_search_mode"):
+            _declare("websearch_mode", assistant.get("web_search_mode"))
+        if assistant.get("web_search_allowed_domains"):
+            _declare("websearch_domains", assistant.get("web_search_allowed_domains"))
+        if assistant.get("web_search_location"):
+            _declare("websearch_location", assistant.get("web_search_location"))
+        if assistant.get("add_to_user_message"):
+            _declare("append_to_user_message", assistant.get("add_to_user_message"))
+        if assistant.get("messages_window_to_generator") is not None:
+            _declare(
+                "user_interactions_window", int(assistant.get("messages_window_to_generator"))
+            )
+        if token_strategy:
+            _declare(
+                "token_optimization",
+                assistant.get("strategy_to_optimize_tokens"),
+                f"optimizations.{token_strategy}()",
+            )
+        if attachment_specs:
+            declared_extras["attachments"] = _attachment_state(attachment_specs)
+
+        _extra_fields = "".join(f"{line}\n" for line in extra_lines)
+        _extra_fields += _attachment_source(attachment_specs)
+
+        imports = ["BaseAgent", "genconfigs"]
+        if attachment_specs:
+            imports.append("attachment")
+        if token_strategy:
+            imports.append("optimizations")
+        agent_imports = ", ".join(imports)
+
+        agent_py = f"""from cogsol.agents import {agent_imports}
 from cogsol.prompts import Prompts
 from ..tools import *
 
@@ -909,10 +1050,7 @@ class {class_name}(BaseAgent):
             "initial_message": assistant.get("initial_message"),
             "forced_termination_message": assistant.get("end_message"),
             "no_information_message": assistant.get("not_info_message"),
-            "streaming": assistant.get("streaming_available"),
-            "realtime": assistant.get("realtime_available"),
-            "reasoning": assistant.get("reasoning_available"),
-            "websearch": assistant.get("websearch_available"),
+            **declared_extras,
             "tools": [n for n in (_tool_name_for_id(sid) for sid in tools_ids) if n],
             "pretools": [n for n in (_tool_name_for_id(sid) for sid in pretools_ids) if n],
             "faqs": [

--- a/cogsol/management/commands/importagent.py
+++ b/cogsol/management/commands/importagent.py
@@ -652,9 +652,7 @@ class Command(BaseCommand):
         if assistant.get("add_to_user_message"):
             _declare("append_to_user_message", assistant.get("add_to_user_message"))
         if assistant.get("messages_window_to_generator") is not None:
-            _declare(
-                "user_interactions_window", int(assistant.get("messages_window_to_generator"))
-            )
+            _declare("user_interactions_window", int(assistant.get("messages_window_to_generator")))
         if token_strategy:
             _declare(
                 "token_optimization",

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -1447,9 +1447,7 @@ class Command(BaseCommand):
 
         # Not nullable in Cognitive: None means "not configured", keep the remote value.
         _set_if_declared("asynchronous", "async_available", bool, allow_none=False)
-        _set_if_declared(
-            "self_improvement_mode", "matrix_mode_available", bool, allow_none=False
-        )
+        _set_if_declared("self_improvement_mode", "matrix_mode_available", bool, allow_none=False)
         _set_if_declared(
             "user_interactions_window", "messages_window_to_generator", int, allow_none=False
         )

--- a/cogsol/management/commands/migrate.py
+++ b/cogsol/management/commands/migrate.py
@@ -10,7 +10,16 @@ import textwrap
 from pathlib import Path
 from typing import Any, Optional, cast
 
-from cogsol.agents import genconfigs
+from cogsol.agents import (
+    ATTACHMENT_CONTENT_TYPES,
+    PDF_CONTENT_TYPE,
+    PDF_MODES,
+    REASONING_EFFORTS,
+    REASONING_SUMMARIES,
+    WEBSEARCH_MODES,
+    BaseAgent,
+    genconfigs,
+)
 from cogsol.content import BaseRetrieval
 from cogsol.core import migrations as migutils
 from cogsol.core.api import CogSolAPIError, CogSolClient
@@ -49,6 +58,71 @@ def sub_slug(cls: type | None) -> str | None:
         if len(parts) >= 2:
             return parts[1]
     return None
+
+
+def _attachment_spec_fields(agent_name: str, spec: Any) -> tuple[list[str], bool, bool, Any]:
+    """Read one attachment spec, either a live spec object or its migrated dict."""
+    if isinstance(spec, dict):
+        content_types = spec.get("content_types")
+        accepted = spec.get("accepted", True)
+        send_to_model = spec.get("send_to_model", False)
+        mode = spec.get("mode")
+    else:
+        content_types = getattr(spec, "content_types", None)
+        accepted = getattr(spec, "accepted", True)
+        send_to_model = getattr(spec, "send_to_model", False)
+        mode = getattr(spec, "mode", None)
+
+    if isinstance(content_types, str):
+        content_types = [content_types]
+    if not isinstance(content_types, (list, tuple)) or not content_types:
+        raise CogSolAPIError(
+            "Each attachment must declare at least one content type. "
+            f"Fix the attachments of agent '{agent_name}'."
+        )
+    names = [str(item) for item in content_types]
+
+    if send_to_model and not accepted:
+        raise CogSolAPIError(
+            f"Attachment '{names[0]}' of agent '{agent_name}' sets send_to_model without "
+            "accepted. An attachment that is not accepted never reaches the model."
+        )
+    if mode is not None and mode not in PDF_MODES:
+        raise CogSolAPIError(
+            f"Invalid attachment mode '{mode}' for agent '{agent_name}'. "
+            f"Valid modes: {', '.join(PDF_MODES)}."
+        )
+    return names, bool(accepted), bool(send_to_model), mode
+
+
+def _attachment_config_payload(agent_name: str, attachments: Any) -> dict[str, Any]:
+    """Build the Cognitive attachment_config map from an agent's attachment specs."""
+    if attachments is None:
+        return {}
+    if not isinstance(attachments, (list, tuple)):
+        raise CogSolAPIError(
+            f"attachments must be a list of attachment specs. Fix agent '{agent_name}'."
+        )
+
+    config: dict[str, dict[str, Any]] = {}
+    for spec in attachments:
+        content_types, accepted, send_to_model, mode = _attachment_spec_fields(agent_name, spec)
+        for content_type in content_types:
+            if content_type not in ATTACHMENT_CONTENT_TYPES:
+                raise CogSolAPIError(
+                    f"Unsupported attachment content type '{content_type}' for agent "
+                    f"'{agent_name}'. Supported types: {', '.join(ATTACHMENT_CONTENT_TYPES)}."
+                )
+            if content_type in config:
+                raise CogSolAPIError(
+                    f"Attachment content type '{content_type}' is configured twice for agent "
+                    f"'{agent_name}'. Declare each content type once."
+                )
+            entry: dict[str, Any] = {"accepted": accepted, "send_to_model": send_to_model}
+            if content_type == PDF_CONTENT_TYPE:
+                entry["pdf_mode"] = mode or "image"
+            config[content_type] = entry
+    return config
 
 
 class Command(BaseCommand):
@@ -1191,6 +1265,14 @@ class Command(BaseCommand):
                 return meta.get(attr, default)
             return default
 
+        def _is_declared(attr: str) -> bool:
+            """True when the agent itself declares the attribute, not just BaseAgent."""
+            if attr in fields:
+                return True
+            if cls is None:
+                return False
+            return any(attr in k.__dict__ for k in cls.__mro__ if k not in (BaseAgent, object))
+
         def _normalize_config(value: Any, default: str = "default") -> str:
             if value is None:
                 return default
@@ -1318,7 +1400,6 @@ class Command(BaseCommand):
             ),
             "initial_message": _get("initial_message"),
             "end_message": _get("forced_termination_message"),
-            "add_to_user_message": None,
             "max_consecutive_tool_calls": _int_or_default(
                 _first_non_none(
                     _get("max_consecutive_tool_calls"),
@@ -1326,9 +1407,7 @@ class Command(BaseCommand):
                 ),
                 default=0,
             ),
-            "matrix_mode_available": bool(_get("realtime", False)),
             "not_info_message": _get("no_information_message"),
-            "strategy_to_optimize_tokens": None,
             "faq_available": bool(getattr(cls, "faqs", []) if cls else fields.get("faqs")),
             "fixed_available": bool(
                 getattr(cls, "fixed_responses", []) if cls else fields.get("fixed_responses")
@@ -1337,8 +1416,8 @@ class Command(BaseCommand):
                 getattr(cls, "lessons", []) if cls else fields.get("lessons")
             ),
             "realtime_available": bool(_get("realtime", False)),
-            "reasoning_available": bool(_get("reasoning", False)),
-            "websearch_available": bool(_get("websearch", False)),
+            "reasoning_enabled": bool(_get("reasoning", False)),
+            "web_search_enabled": bool(_get("websearch", False)),
             "info": _get_meta("alias") or _get_meta("chat_name"),
             "colors": colors,
             "logo": _get_meta("logo_url"),
@@ -1346,7 +1425,82 @@ class Command(BaseCommand):
             "tools": tool_ids,
             "pretools": pretool_ids,
         }
+
+        # Only sent when declared, so what is left to the portal survives a migrate.
+        def _set_if_declared(attr: str, key: str, cast_value=None, allow_none: bool = True) -> None:
+            if not _is_declared(attr):
+                return
+            value = _get(attr)
+            if value is None:
+                if not allow_none:
+                    return
+                payload[key] = None
+                return
+            payload[key] = cast_value(value) if cast_value is not None else value
+
+        # Nullable in Cognitive: an explicit None clears the field.
+        _set_if_declared("append_to_user_message", "add_to_user_message")
+        _set_if_declared("websearch_domains", "web_search_allowed_domains")
+        _set_if_declared("websearch_location", "web_search_location")
+        _set_if_declared("reasoning_effort", "reasoning_effort")
+        _set_if_declared("reasoning_summary", "reasoning_summary")
+
+        # Not nullable in Cognitive: None means "not configured", keep the remote value.
+        _set_if_declared("asynchronous", "async_available", bool, allow_none=False)
+        _set_if_declared(
+            "self_improvement_mode", "matrix_mode_available", bool, allow_none=False
+        )
+        _set_if_declared(
+            "user_interactions_window", "messages_window_to_generator", int, allow_none=False
+        )
+        _set_if_declared("websearch_mode", "web_search_mode", allow_none=False)
+
+        if _is_declared("token_optimization"):
+            payload["strategy_to_optimize_tokens"] = _normalize_config(
+                _get("token_optimization"), default="no_optimization"
+            )
+
+        if _is_declared("attachments"):
+            payload["attachment_config"] = _attachment_config_payload(
+                agent_name, _get("attachments")
+            )
+
+        self._validate_assistant_payload(agent_name, payload)
         return payload
+
+    def _validate_assistant_payload(self, agent_name: str, payload: dict[str, Any]) -> None:
+        """Reject choice fields Cognitive would accept but never be able to use."""
+        choices = (
+            ("reasoning_effort", REASONING_EFFORTS),
+            ("reasoning_summary", REASONING_SUMMARIES),
+            ("web_search_mode", WEBSEARCH_MODES),
+        )
+        for key, valid in choices:
+            value = payload.get(key)
+            if value is not None and value not in valid:
+                raise CogSolAPIError(
+                    f"Invalid {key} '{value}' for agent '{agent_name}'. "
+                    f"Valid values: {', '.join(valid)}."
+                )
+
+        domains = payload.get("web_search_allowed_domains")
+        if domains is not None and not isinstance(domains, list):
+            raise CogSolAPIError(
+                f"websearch_domains must be a list of domains. Fix agent '{agent_name}'."
+            )
+
+        location = payload.get("web_search_location")
+        if location is not None and not isinstance(location, dict):
+            raise CogSolAPIError(
+                "websearch_location must be a dict with country/city/region/timezone keys. "
+                f"Fix agent '{agent_name}'."
+            )
+
+        if payload.get("matrix_mode_available") and not payload.get("faq_available"):
+            raise CogSolAPIError(
+                f"Agent '{agent_name}' enables self_improvement_mode but declares no FAQs. "
+                "Cognitive matrix mode requires FAQ support."
+            )
 
     def _faq_payload(self, faq_obj: Any) -> dict[str, Any]:
         name = (

--- a/cogsol/management/commands/startagent.py
+++ b/cogsol/management/commands/startagent.py
@@ -23,6 +23,22 @@ class {class_name}(BaseAgent):
     # initial_message = "Hi! how can I help you?"
     # forced_termination_message = "We need to end this chat."
     # no_information_message = "I don't have that information."
+    # Attachments the chat accepts, and which ones reach the model (optional).
+    # Needs: from cogsol.agents import attachment
+    # attachments = [
+    #     attachment.Pdf(send_to_model=True, mode="image"),   # or mode="text"
+    #     attachment.Image(send_to_model=True),
+    #     attachment.Excel(),                                 # accepted, tools only
+    # ]
+    # Reasoning (optional):
+    # reasoning = True
+    # reasoning_effort = "medium"          # low | medium | high | xhigh | none
+    # reasoning_summary = "concise"        # auto | concise | detailed | none
+    # Web search (optional):
+    # websearch = True
+    # websearch_mode = "agentic"           # agentic | deep_research
+    # websearch_domains = ["cogsol.ai"]
+    # websearch_location = {{"country": "AR", "city": "Buenos Aires"}}
 
     class Meta:
         name = "{class_name}"

--- a/docs/agents-tools.md
+++ b/docs/agents-tools.md
@@ -63,6 +63,7 @@ class MyAgent(BaseAgent):
 | `initial_message` | `str` | `None` | First message sent to user |
 | `forced_termination_message` | `str` | `None` | Message when conversation ends |
 | `no_information_message` | `str` | `None` | Response when agent lacks information |
+| `append_to_user_message` | `str` | `None` | Text appended to every user message |
 
 ```python
 from cogsol.agents import BaseAgent
@@ -115,17 +116,20 @@ Use script tools (`BaseTool`) for capabilities/actions and retrieval tools (`Bas
 
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_interactions` | `int` | `None` | Max conversation turns |
+| `max_interactions` | `int` | `None` | Max conversation turns (`-1` for unlimited) |
 | `user_message_length` | `int` | `None` | Max user message characters |
 | `consecutive_tool_calls_limit` | `int` | `None` | Max tool calls in sequence |
-| `user_interactions_window` | `int` | `None` | Context window for interactions |
+| `user_interactions_window` | `int` | `None` | Messages of history sent to the model (`-1` for all) |
 
 ```python
 class LimitedAgent(BaseAgent):
     max_interactions = 10
     user_message_length = 2048
     consecutive_tool_calls_limit = 5
+    user_interactions_window = 20
 ```
+
+> **Note:** `max_interactions` and `user_interactions_window` cannot both be `-1`.
 
 #### Features
 
@@ -133,14 +137,91 @@ class LimitedAgent(BaseAgent):
 |-----------|------|---------|-------------|
 | `streaming` | `bool` | `False` | Enable response streaming |
 | `realtime` | `bool` | `False` | Enable real-time mode |
-| `self_improvement_mode` | `bool` | `False` | Enable self-improvement |
-| `token_optimization` | `Any` | `None` | Token optimization strategy |
+| `asynchronous` | `bool` | `False` | Enable asynchronous responses |
+| `self_improvement_mode` | `bool` | `False` | Enable self-improvement (Cognitive matrix mode). Requires FAQs and is rejected in production |
+| `token_optimization` | `optimizations.*` | `None` | Token optimization strategy |
 
 ```python
+from cogsol.agents import BaseAgent, optimizations
+
 class StreamingAgent(BaseAgent):
     streaming = True
     realtime = False
+    token_optimization = optimizations.DescriptionOnly()
 ```
+
+Available strategies: `optimizations.DescriptionOnly()` keeps only the description of
+past retrieval results, `optimizations.SkipAllContent()` drops their content entirely,
+and `optimizations.NoOptimization()` sends the full history.
+
+#### Reasoning
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `reasoning` | `bool` | `False` | Enable reasoning |
+| `reasoning_effort` | `str` | `None` | `low`, `medium`, `high`, `xhigh` or `none` |
+| `reasoning_summary` | `str` | `None` | `auto`, `concise`, `detailed` or `none` |
+
+```python
+class AnalystAgent(BaseAgent):
+    reasoning = True
+    reasoning_effort = "high"
+    reasoning_summary = "concise"
+```
+
+#### Web Search
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `websearch` | `bool` | `False` | Enable web search |
+| `websearch_mode` | `str` | `None` | `agentic` or `deep_research` |
+| `websearch_domains` | `list[str]` | `None` | Allow-list of domains (max. 100, no protocol or path) |
+| `websearch_location` | `dict` | `None` | `country` (2-letter ISO), `city`, `region`, `timezone` |
+
+```python
+class ResearchAgent(BaseAgent):
+    websearch = True
+    websearch_mode = "agentic"
+    websearch_domains = ["cogsol.ai", "python.org"]
+    websearch_location = {"country": "AR", "city": "Buenos Aires"}
+```
+
+#### Attachments
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `attachments` | `list[attachment.*]` | `[]` | File types the chat accepts, and which ones reach the model |
+
+```python
+from cogsol.agents import BaseAgent, attachment
+
+class SupportAgent(BaseAgent):
+    attachments = [
+        attachment.Pdf(send_to_model=True, mode="text"),
+        attachment.Image(send_to_model=True),
+        attachment.Excel(),
+    ]
+```
+
+Every spec takes `accepted` (default `True`) — whether the chat lets the user upload
+the file — and `send_to_model` (default `False`) — whether its content reaches the
+model. An accepted file that is not sent to the model is still available to tools.
+
+| Spec | Content types |
+|------|---------------|
+| `attachment.Pdf` | `application/pdf` — `mode="image"` sends the raw file, `mode="text"` sends extracted text |
+| `attachment.Image` | `image/png`, `image/jpeg` (always delivered as raw files) |
+| `attachment.Word` | `.docx` |
+| `attachment.Excel` | `.xlsx`, `.xls` |
+| `attachment.Text` | `text/plain` |
+| `attachment.Markdown` | `text/markdown`, `text/x-markdown` |
+| `attachment.Latex` | `text/x-tex`, `application/x-tex`, `application/x-latex` |
+| `attachment.Binary` | `application/octet-stream` |
+| `attachment.Custom` | Any accepted type, passed explicitly via `content_types` |
+
+Declaring `attachments = []` accepts no attachments at all. Omitting the attribute
+leaves whatever is configured in the portal untouched — the same rule applies to every
+optional attribute above.
 
 #### Related Content
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,8 +5,8 @@ Tests for the agents module.
 import tempfile
 from pathlib import Path
 
-from cogsol.agents import BaseAgent, genconfigs, optimizations
-from cogsol.core.loader import collect_classes, collect_definitions
+from cogsol.agents import BaseAgent, attachment, genconfigs, optimizations
+from cogsol.core.loader import collect_classes, collect_definitions, serialize_value
 from cogsol.core.migrations import diff_states, empty_state
 from cogsol.db.migrations import (
     AlterField,
@@ -54,6 +54,49 @@ class TestBaseAgent:
         assert CustomAgent.streaming is True
         assert issubclass(CustomAgent, BaseAgent)
 
+    def test_optional_configuration_defaults(self):
+        """Optional configuration should default to "not configured"."""
+        assert BaseAgent.attachments == []
+        assert BaseAgent.asynchronous is False
+        assert BaseAgent.self_improvement_mode is False
+        assert BaseAgent.append_to_user_message is None
+        assert BaseAgent.reasoning_effort is None
+        assert BaseAgent.reasoning_summary is None
+        assert BaseAgent.websearch_mode is None
+        assert BaseAgent.websearch_domains is None
+        assert BaseAgent.websearch_location is None
+
+
+class TestAttachmentSpecs:
+    """Tests for attachment specifications."""
+
+    def test_named_specs_carry_their_content_types(self):
+        """Each named spec should resolve to the content types it covers."""
+        assert attachment.Pdf().content_types == ("application/pdf",)
+        assert attachment.Image().content_types == ("image/png", "image/jpeg")
+        assert attachment.Markdown().content_types == ("text/markdown", "text/x-markdown")
+
+    def test_defaults_accept_without_sending_to_model(self):
+        """An attachment should be uploadable but kept away from the model by default."""
+        spec = attachment.Text()
+        assert spec.accepted is True
+        assert spec.send_to_model is False
+
+    def test_serialization_keeps_every_setting(self):
+        """Migration state must keep the flags so changes show up in the diff."""
+        serialized = serialize_value(attachment.Pdf(send_to_model=True, mode="text"))
+
+        assert serialized == {
+            "accepted": True,
+            "content_types": ["application/pdf"],
+            "mode": "text",
+            "send_to_model": True,
+        }
+
+    def test_serialization_distinguishes_specs_with_equal_flags(self):
+        """Two formats sharing flags must not collapse into the same state."""
+        assert serialize_value(attachment.Text()) != serialize_value(attachment.Binary())
+
 
 class TestGenConfigs:
     """Tests for generation configurations."""
@@ -81,6 +124,14 @@ class TestOptimizations:
         """DescriptionOnly should have correct name."""
         opt = optimizations.DescriptionOnly()
         assert opt.name == "description_only"
+
+    def test_skip_all_content(self):
+        """SkipAllContent should have correct name."""
+        assert optimizations.SkipAllContent().name == "skip_all_content"
+
+    def test_no_optimization(self):
+        """NoOptimization should have correct name."""
+        assert optimizations.NoOptimization().name == "no_optimization"
 
 
 class TestAgentFaqDiffs:

--- a/tests/test_importagent.py
+++ b/tests/test_importagent.py
@@ -1,0 +1,175 @@
+"""
+Tests for importing an existing assistant back into a project.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cogsol.core.loader import collect_definitions
+from cogsol.management.commands import importagent
+from cogsol.management.commands.importagent import Command
+from cogsol.management.commands.migrate import Command as MigrateCommand
+
+ASSISTANT: dict[str, Any] = {
+    "id": 42,
+    "description": "Support",
+    "info": "Soporte",
+    "system_prompt": "You are support.",
+    "generation_config": "QA",
+    "generation_config_pretools": "QA",
+    "temperature": 0.3,
+    "max_responses": 5,
+    "max_msg_length": 2048,
+    "max_consecutive_tool_calls": 3,
+    "messages_window_to_generator": 12,
+    "initial_message": "Hello!",
+    "end_message": "Goodbye.",
+    "not_info_message": "I don't have that information.",
+    "add_to_user_message": " (be brief)",
+    "strategy_to_optimize_tokens": "description_only",
+    "streaming_available": True,
+    "realtime_available": False,
+    "async_available": True,
+    "matrix_mode_available": True,
+    "reasoning_enabled": True,
+    "reasoning_effort": "high",
+    "reasoning_summary": "concise",
+    "web_search_enabled": True,
+    "web_search_mode": "agentic",
+    "web_search_allowed_domains": ["cogsol.ai"],
+    "web_search_location": {"country": "AR", "city": "Buenos Aires"},
+    "attachment_config": {
+        "application/pdf": {"accepted": True, "send_to_model": True, "pdf_mode": "text"},
+        "image/png": {"accepted": True, "send_to_model": True},
+        "image/jpeg": {"accepted": True, "send_to_model": True},
+        "text/plain": {"accepted": True, "send_to_model": False},
+    },
+    "colors": {"primaryColor": "#1A3C5E"},
+    "logo": "https://example.test/logo.png",
+    "tools": [],
+    "pretools": [],
+}
+
+
+class _StubClient:
+    """Stands in for CogSolClient, serving a single assistant with no tools."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def get_assistant(self, assistant_id: int) -> dict[str, Any]:
+        return dict(ASSISTANT)
+
+    def list_common_questions(self, assistant_id: int) -> list[dict[str, Any]]:
+        return [{"id": 1, "name": "How do I start?", "content": "Just ask."}]
+
+    def list_fixed_responses(self, assistant_id: int) -> list[dict[str, Any]]:
+        return []
+
+    def list_lessons(self, assistant_id: int) -> list[dict[str, Any]]:
+        return []
+
+
+@pytest.fixture
+def imported_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run importagent against the stub client and return the project path."""
+    monkeypatch.setattr(importagent, "CogSolClient", _StubClient)
+    monkeypatch.setattr(Command, "ensure_credentials_configured", lambda self, path: True)
+
+    agents = tmp_path / "agents"
+    (agents / "migrations").mkdir(parents=True)
+    (agents / "__init__.py").write_text("", encoding="utf-8")
+    (agents / "tools.py").write_text("", encoding="utf-8")
+    (agents / "migrations" / "__init__.py").write_text("", encoding="utf-8")
+
+    assert Command().handle(project_path=tmp_path, assistant_id=42, app="agents") == 0
+    return tmp_path
+
+
+class TestImportedAgentSource:
+    def test_generated_agent_is_valid_python(self, imported_project: Path) -> None:
+        source = (imported_project / "agents" / "support" / "agent.py").read_text(encoding="utf-8")
+
+        ast.parse(source)
+
+    def test_imports_only_the_namespaces_it_uses(self, imported_project: Path) -> None:
+        source = (imported_project / "agents" / "support" / "agent.py").read_text(encoding="utf-8")
+
+        assert "attachment" in source.splitlines()[0]
+        assert "optimizations" in source.splitlines()[0]
+
+    def test_declares_the_optional_configuration(self, imported_project: Path) -> None:
+        source = (imported_project / "agents" / "support" / "agent.py").read_text(encoding="utf-8")
+
+        for expected in (
+            "streaming = True",
+            "asynchronous = True",
+            "self_improvement_mode = True",
+            "reasoning = True",
+            "reasoning_effort = 'high'",
+            "reasoning_summary = 'concise'",
+            "websearch = True",
+            "websearch_mode = 'agentic'",
+            "websearch_domains = ['cogsol.ai']",
+            "append_to_user_message = ' (be brief)'",
+            "user_interactions_window = 12",
+            "token_optimization = optimizations.DescriptionOnly()",
+            "attachment.Pdf(accepted=True, send_to_model=True, mode='text')",
+            "attachment.Image(accepted=True, send_to_model=True)",
+        ):
+            assert expected in source
+
+    def test_does_not_declare_disabled_features(self, imported_project: Path) -> None:
+        source = (imported_project / "agents" / "support" / "agent.py").read_text(encoding="utf-8")
+
+        assert "realtime" not in source
+
+
+class TestImportedAgentRoundTrip:
+    """A migrate of the imported project must reproduce the assistant it came from."""
+
+    def _payload(self, project_path: Path) -> dict[str, Any]:
+        definitions = collect_definitions(project_path, "agents")
+        return MigrateCommand()._assistant_payload(
+            agent_name="SupportAgent",
+            definition=definitions["agents"]["SupportAgent"],
+            cls=None,
+            remote_ids={},
+            project_path=project_path,
+            app="agents",
+            slug="support",
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "attachment_config",
+            "reasoning_enabled",
+            "reasoning_effort",
+            "reasoning_summary",
+            "web_search_enabled",
+            "web_search_mode",
+            "web_search_allowed_domains",
+            "web_search_location",
+            "async_available",
+            "matrix_mode_available",
+            "add_to_user_message",
+            "messages_window_to_generator",
+            "strategy_to_optimize_tokens",
+            "streaming_available",
+        ],
+    )
+    def test_field_survives_the_round_trip(self, imported_project: Path, field: str) -> None:
+        payload = self._payload(imported_project)
+
+        assert payload[field] == ASSISTANT[field]
+
+    def test_undeclared_features_stay_out_of_the_payload(self, imported_project: Path) -> None:
+        payload = self._payload(imported_project)
+
+        assert payload["realtime_available"] is False

--- a/tests/test_migrate_agents.py
+++ b/tests/test_migrate_agents.py
@@ -1,0 +1,344 @@
+"""
+Tests for the assistant payload built during migrations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cogsol.agents import BaseAgent, attachment, optimizations
+from cogsol.core.api import CogSolAPIError
+from cogsol.core.loader import serialize_value
+from cogsol.management.commands.importagent import (
+    _attachment_source,
+    _attachment_specs_from_config,
+    _attachment_state,
+)
+from cogsol.management.commands.migrate import Command
+
+PDF = "application/pdf"
+PNG = "image/png"
+JPEG = "image/jpeg"
+XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+XLS = "application/vnd.ms-excel"
+
+
+def _payload(cls: type | None = None, fields: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build an assistant payload from a live class, a state dict, or both."""
+    return Command()._assistant_payload(
+        agent_name=getattr(cls, "__name__", "DemoAgent"),
+        definition={"fields": fields or {}, "meta": {}},
+        cls=cls,
+        remote_ids={},
+        project_path=Path("."),
+        app="agents",
+    )
+
+
+class TestOptionalFieldsAreOnlySentWhenDeclared:
+    def test_undeclared_optional_fields_are_absent(self) -> None:
+        class DemoAgent(BaseAgent):
+            temperature = 0.3
+
+        payload = _payload(DemoAgent)
+
+        for key in (
+            "add_to_user_message",
+            "strategy_to_optimize_tokens",
+            "messages_window_to_generator",
+            "matrix_mode_available",
+            "async_available",
+            "attachment_config",
+            "reasoning_effort",
+            "reasoning_summary",
+            "web_search_mode",
+            "web_search_allowed_domains",
+            "web_search_location",
+        ):
+            assert key not in payload
+
+    def test_base_agent_defaults_do_not_count_as_declared(self) -> None:
+        class DemoAgent(BaseAgent):
+            pass
+
+        assert "async_available" not in _payload(DemoAgent)
+
+    def test_declared_values_are_sent(self) -> None:
+        class DemoAgent(BaseAgent):
+            append_to_user_message = " (be brief)"
+            user_interactions_window = 8
+            asynchronous = True
+            websearch_domains = ["cogsol.ai"]
+            websearch_location = {"country": "AR"}
+
+        payload = _payload(DemoAgent)
+
+        assert payload["add_to_user_message"] == " (be brief)"
+        assert payload["messages_window_to_generator"] == 8
+        assert payload["async_available"] is True
+        assert payload["web_search_allowed_domains"] == ["cogsol.ai"]
+        assert payload["web_search_location"] == {"country": "AR"}
+
+    def test_declared_none_clears_nullable_field(self) -> None:
+        class DemoAgent(BaseAgent):
+            append_to_user_message = None
+
+        assert _payload(DemoAgent)["add_to_user_message"] is None
+
+    def test_declared_none_is_skipped_for_non_nullable_field(self) -> None:
+        class DemoAgent(BaseAgent):
+            user_interactions_window = None
+
+        assert "messages_window_to_generator" not in _payload(DemoAgent)
+
+    def test_state_only_definitions_are_honoured(self) -> None:
+        payload = _payload(None, {"asynchronous": True, "user_interactions_window": 4})
+
+        assert payload["async_available"] is True
+        assert payload["messages_window_to_generator"] == 4
+
+
+class TestReasoningAndWebSearchMapping:
+    def test_reasoning_uses_the_field_cognitive_exposes(self) -> None:
+        class DemoAgent(BaseAgent):
+            reasoning = True
+            reasoning_effort = "high"
+            reasoning_summary = "concise"
+
+        payload = _payload(DemoAgent)
+
+        assert payload["reasoning_enabled"] is True
+        assert payload["reasoning_effort"] == "high"
+        assert payload["reasoning_summary"] == "concise"
+        assert "reasoning_available" not in payload
+
+    def test_websearch_uses_the_field_cognitive_exposes(self) -> None:
+        class DemoAgent(BaseAgent):
+            websearch = True
+            websearch_mode = "deep_research"
+
+        payload = _payload(DemoAgent)
+
+        assert payload["web_search_enabled"] is True
+        assert payload["web_search_mode"] == "deep_research"
+        assert "websearch_available" not in payload
+
+    @pytest.mark.parametrize(
+        ("attr", "value"),
+        [
+            ("reasoning_effort", "extreme"),
+            ("reasoning_summary", "verbose"),
+            ("websearch_mode", "agentic_deep"),
+        ],
+    )
+    def test_invalid_choice_is_rejected(self, attr: str, value: str) -> None:
+        cls = type("DemoAgent", (BaseAgent,), {attr: value})
+
+        with pytest.raises(CogSolAPIError, match="Valid values"):
+            _payload(cls)
+
+    def test_websearch_domains_must_be_a_list(self) -> None:
+        class DemoAgent(BaseAgent):
+            websearch_domains = "cogsol.ai"
+
+        with pytest.raises(CogSolAPIError, match="must be a list of domains"):
+            _payload(DemoAgent)
+
+    def test_websearch_location_must_be_a_dict(self) -> None:
+        class DemoAgent(BaseAgent):
+            websearch_location = "AR"
+
+        with pytest.raises(CogSolAPIError, match="websearch_location must be a dict"):
+            _payload(DemoAgent)
+
+
+class TestSelfImprovementMode:
+    def test_realtime_does_not_enable_matrix_mode(self) -> None:
+        class DemoAgent(BaseAgent):
+            realtime = True
+
+        payload = _payload(DemoAgent)
+
+        assert payload["realtime_available"] is True
+        assert "matrix_mode_available" not in payload
+
+    def test_self_improvement_mode_requires_faqs(self) -> None:
+        class DemoAgent(BaseAgent):
+            self_improvement_mode = True
+
+        with pytest.raises(CogSolAPIError, match="declares no FAQs"):
+            _payload(DemoAgent)
+
+    def test_self_improvement_mode_with_faqs(self) -> None:
+        class DemoAgent(BaseAgent):
+            self_improvement_mode = True
+            faqs = [object()]
+
+        payload = _payload(DemoAgent)
+
+        assert payload["matrix_mode_available"] is True
+        assert payload["faq_available"] is True
+
+
+class TestTokenOptimization:
+    def test_strategy_is_sent_when_declared(self) -> None:
+        class DemoAgent(BaseAgent):
+            token_optimization = optimizations.SkipAllContent()
+
+        assert _payload(DemoAgent)["strategy_to_optimize_tokens"] == "skip_all_content"
+
+    def test_declared_none_falls_back_to_no_optimization(self) -> None:
+        class DemoAgent(BaseAgent):
+            token_optimization = None
+
+        assert _payload(DemoAgent)["strategy_to_optimize_tokens"] == "no_optimization"
+
+    def test_strategy_from_state(self) -> None:
+        payload = _payload(None, {"token_optimization": "description_only"})
+
+        assert payload["strategy_to_optimize_tokens"] == "description_only"
+
+
+class TestAttachmentConfig:
+    def test_specs_become_attachment_config(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [
+                attachment.Pdf(send_to_model=True, mode="text"),
+                attachment.Image(send_to_model=True),
+                attachment.Excel(),
+            ]
+
+        config = _payload(DemoAgent)["attachment_config"]
+
+        assert config[PDF] == {"accepted": True, "send_to_model": True, "pdf_mode": "text"}
+        assert config[PNG] == {"accepted": True, "send_to_model": True}
+        assert config[JPEG] == {"accepted": True, "send_to_model": True}
+        assert config[XLSX] == {"accepted": True, "send_to_model": False}
+        assert config[XLS] == {"accepted": True, "send_to_model": False}
+
+    def test_pdf_defaults_to_image_mode(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Pdf()]
+
+        assert _payload(DemoAgent)["attachment_config"][PDF]["pdf_mode"] == "image"
+
+    def test_empty_list_clears_the_configuration(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = []
+
+        assert _payload(DemoAgent)["attachment_config"] == {}
+
+    def test_migrated_state_matches_live_specs(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Pdf(send_to_model=True, mode="text"), attachment.Text()]
+
+        from_class = _payload(DemoAgent)["attachment_config"]
+        from_state = _payload(None, {"attachments": serialize_value(DemoAgent.attachments)})[
+            "attachment_config"
+        ]
+
+        assert from_class == from_state
+
+    def test_custom_accepts_extra_content_types(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Custom(content_types=(XLS,), send_to_model=True)]
+
+        assert _payload(DemoAgent)["attachment_config"] == {
+            XLS: {"accepted": True, "send_to_model": True}
+        }
+
+    def test_unsupported_content_type_is_rejected(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Custom(content_types=("audio/mpeg",))]
+
+        with pytest.raises(CogSolAPIError, match="Unsupported attachment content type"):
+            _payload(DemoAgent)
+
+    def test_duplicated_content_type_is_rejected(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Text(), attachment.Custom(content_types=("text/plain",))]
+
+        with pytest.raises(CogSolAPIError, match="configured twice"):
+            _payload(DemoAgent)
+
+    def test_invalid_pdf_mode_is_rejected(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Pdf(mode="binary")]
+
+        with pytest.raises(CogSolAPIError, match="Invalid attachment mode"):
+            _payload(DemoAgent)
+
+    def test_send_to_model_without_accepted_is_rejected(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Image(accepted=False, send_to_model=True)]
+
+        with pytest.raises(CogSolAPIError, match="never reaches the model"):
+            _payload(DemoAgent)
+
+    def test_spec_without_content_types_is_rejected(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = [attachment.Custom()]
+
+        with pytest.raises(CogSolAPIError, match="at least one content type"):
+            _payload(DemoAgent)
+
+    def test_attachments_must_be_a_list(self) -> None:
+        class DemoAgent(BaseAgent):
+            attachments = attachment.Pdf()
+
+        with pytest.raises(CogSolAPIError, match="attachments must be a list"):
+            _payload(DemoAgent)
+
+
+class TestAttachmentConfigImport:
+    def test_named_groups_are_reconstructed(self) -> None:
+        specs = _attachment_specs_from_config(
+            {
+                PDF: {"accepted": True, "send_to_model": True, "pdf_mode": "text"},
+                PNG: {"accepted": True, "send_to_model": True},
+                JPEG: {"accepted": True, "send_to_model": True},
+            }
+        )
+
+        assert [name for name, _, _ in specs] == ["Image", "Pdf"]
+        assert "attachment.Pdf(accepted=True, send_to_model=True, mode='text')" in (
+            _attachment_source(specs)
+        )
+
+    def test_leftover_types_become_custom(self) -> None:
+        specs = _attachment_specs_from_config({XLS: {"accepted": True, "send_to_model": False}})
+
+        assert [name for name, _, _ in specs] == ["Custom"]
+
+    def test_generated_source_matches_generated_state(self) -> None:
+        specs = _attachment_specs_from_config(
+            {
+                PDF: {"accepted": True, "send_to_model": True, "pdf_mode": "image"},
+                "text/plain": {"accepted": True, "send_to_model": False},
+            }
+        )
+        source = _attachment_source(specs).replace("    attachments", "attachments", 1)
+        namespace: dict[str, Any] = {"attachment": attachment}
+        exec(source, namespace)
+
+        assert serialize_value(namespace["attachments"]) == _attachment_state(specs)
+
+    def test_empty_config_produces_no_specs(self) -> None:
+        assert _attachment_specs_from_config(None) == []
+        assert _attachment_specs_from_config({}) == []
+        assert _attachment_source([]) == ""
+
+    def test_round_trip_through_the_payload_builder(self) -> None:
+        config = {
+            PDF: {"accepted": True, "send_to_model": True, "pdf_mode": "text"},
+            PNG: {"accepted": True, "send_to_model": False},
+            JPEG: {"accepted": True, "send_to_model": False},
+        }
+        specs = _attachment_specs_from_config(config)
+
+        payload = _payload(None, {"attachments": _attachment_state(specs)})
+
+        assert payload["attachment_config"] == config


### PR DESCRIPTION
# Summary

Adds the Assistant configuration the framework could not express — attachments, reasoning detail, web search scope, and several fields that were declared but never sent — and stops `migrate` from overwriting configuration owned by the portal.

## Changes

### Attachments

- New `attachment` namespace in `cogsol/agents/__init__.py` with `Pdf`, `Image`, `Word`, `Excel`, `Text`, `Markdown`, `Latex`, `Binary` and `Custom` specs. Each takes `accepted` and `send_to_model`; `Pdf` takes `mode="image"|"text"`.
- `BaseAgent.attachments` is translated into the Cognitive `attachment_config` map by `_attachment_config_payload`. Declaring `attachments = []` accepts no attachments.
- Specs are plain dataclasses with `content_types` as a field rather than a ClassVar, so `serialize_value` keeps every setting and the migration diff detects a changed flag or `mode`.

### New configuration attributes

- `reasoning_effort` and `reasoning_summary`.
- `websearch_mode`, `websearch_domains` and `websearch_location`.
- `asynchronous`, mapped to `async_available`.
- `append_to_user_message`, mapped to `add_to_user_message`.
- `optimizations.SkipAllContent()` and `optimizations.NoOptimization()`, completing the strategies the Generator recognizes.

### Attributes that never reached Cognitive

Declared and documented, but absent from the payload. Agents already declaring them will see their behaviour change on the next `migrate`.

- `user_interactions_window` → `messages_window_to_generator`.
- `token_optimization` → `strategy_to_optimize_tokens`.
- `self_improvement_mode` → `matrix_mode_available`.

### Fixes

- `reasoning` and `websearch` had no effect: they were sent as `reasoning_available` and `websearch_available`, fields that do not exist in Cognitive, so they were discarded. They are now sent as `reasoning_enabled` and `web_search_enabled`. **Agents already declaring these flags will actually enable the feature on the next `migrate`, which changes the cost per message.** `importagent` read the same non-existent fields.
- `add_to_user_message` and `strategy_to_optimize_tokens` were hardcoded to `null` in every payload, overwriting whatever was configured in the portal on each run.
- `matrix_mode_available` was derived from `realtime`. They are separate features: matrix mode requires FAQ support and is rejected in production, so a `realtime` agent without FAQs failed to migrate.
- `importagent` wrote migration state for attributes the generated agent does not declare, which made the first `makemigrations` after an import report changes that were not there.

### Payload semantics

- `_is_declared` and `_set_if_declared` in `_assistant_payload`: the new keys are sent only when the agent class declares them, so configuration left to the portal survives a `migrate`. The keys already sent in previous versions keep being sent unconditionally.

### Local validation

Cognitive does not run `Assistant.clean()` on API writes, so an invalid value used to be persisted silently and never work.

- `_validate_assistant_payload` rejects invalid reasoning and web search choices, a non-list `websearch_domains`, a non-dict `websearch_location`, and `self_improvement_mode` without FAQs.
- Attachment specs reject unsupported content types, a content type configured twice, an invalid `pdf_mode`, and `send_to_model` without `accepted`.

### importagent

- Imports every field above, rebuilding `attachments` from the remote `attachment_config` via `_attachment_specs_from_config`, and declares `streaming` and `realtime` in the generated agent instead of only in the migration state.

### Docs

- `docs/agents-tools.md`: new Attachments, Reasoning and Web Search sections; Features and Limits tables updated.

### Tests

- New `tests/test_migrate_agents.py`: payload building, only-if-declared semantics, attachment translation, and every validation error.
- New `tests/test_importagent.py`: runs the command against a stubbed client and asserts the generated agent round-trips back to the assistant it came from.
- `tests/test_agents.py`: attachment spec serialization and optional attribute defaults.
